### PR TITLE
Use SCSS for bootstrap-vue instead of CSS. 

### DIFF
--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -2,8 +2,6 @@ import Vue from 'vue';
 import App from './App.vue';
 import "./styles/index.scss";
 
-import "bootstrap-vue/dist/bootstrap-vue.css"
-
 import { BootstrapVue } from 'bootstrap-vue'
 
 Vue.config.productionTip = true;

--- a/web/src/styles/index.scss
+++ b/web/src/styles/index.scss
@@ -2,6 +2,7 @@
 /* You can add global styles to this file, and also import other style files */
 $bcgov-font-path: "../../node_modules/@bcgov/bootstrap-theme/dist/fonts/";
 @import "~@bcgov/bootstrap-theme/dist/scss/bootstrap-theme";
+@import "~bootstrap-vue/src/index.scss";
 
 .breadcrumb {
   margin-bottom: 0;
@@ -243,3 +244,4 @@ $indicator-thickness: 0.2em;
 //   width: 100%;
 //   height: 3.5rem; /* Footer height */
 // }
+


### PR DESCRIPTION
This should load the styles in the correct order.