### PR TITLE
Configuration exception fix, Criminal/{fileId} route work

### DIFF
--- a/api/Controllers/FilesController.cs
+++ b/api/Controllers/FilesController.cs
@@ -190,19 +190,6 @@ namespace Scv.Api.Controllers
         }
 
         /// <summary>
-        /// Get document details for a given file id.
-        /// </summary>
-        /// <param name="fileId">Target file id.</param>
-        /// <returns>CriminalFileDetailResponse</returns>
-        [HttpGet]
-        [Route("criminal/{fileId}/documents")]
-        public async Task<ActionResult<ICollection<CriminalDocument>>> GetCriminalFilecontentDocumentsAsync(string fileId)
-        {
-            var redactedCriminalFileDetailResponse = await _filesService.FilesCriminalFilecontentDocumentsAsync(fileId);
-            return Ok(redactedCriminalFileDetailResponse);
-        }
-
-        /// <summary>
         /// Gets records of proceedings.
         /// </summary>
         /// <param name="partId">The participant id associated to the Record Of Proceedings.</param>

--- a/api/Helpers/ConfigurationExtensions.cs
+++ b/api/Helpers/ConfigurationExtensions.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Extensions.Configuration;
+using Scv.Api.Helpers.Exceptions;
+
+namespace Scv.Api.Helpers
+{
+    public static class ConfigurationExtension
+    {
+        public static string GetNonEmptyValue(this IConfiguration configuration, string key)
+        {
+            var configurationValue = configuration.GetValue<string>(key);
+            return string.IsNullOrEmpty(configurationValue)
+                ? throw new ConfigurationException($"Configuration '{key}' is invalid or missing.")
+                : configurationValue;
+        }
+    }
+}

--- a/api/Models/Criminal/Content/CriminalDocument.cs
+++ b/api/Models/Criminal/Content/CriminalDocument.cs
@@ -17,7 +17,7 @@ namespace Scv.Api.Models.Criminal.Content
             NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string DocumentTypeDescription { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("documentTypeDescription", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("hasFutureAppearance", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool? HasFutureAppearance { get; set; }
     }
 }

--- a/api/Models/Criminal/Detail/CriminalParticipant.cs
+++ b/api/Models/Criminal/Detail/CriminalParticipant.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using JCCommon.Clients.FileServices;
 using Newtonsoft.Json;
+using Scv.Api.Models.Criminal.Content;
 
 namespace Scv.Api.Models.Criminal.Detail
 {
@@ -10,7 +11,7 @@ namespace Scv.Api.Models.Criminal.Detail
     public class CriminalParticipant
     {
         [JsonProperty("fullName")]
-        public string FullName => $"{GivenNm} {LastNm}";
+        public string FullName => $"{GivenNm?.Trim()} {LastNm?.Trim()}";
 
         [JsonProperty("partId", Required = Required.DisallowNull, NullValueHandling = NullValueHandling.Ignore)]
         public string PartId { get; set; }
@@ -70,5 +71,11 @@ namespace Scv.Api.Models.Criminal.Detail
 
         [JsonProperty("charge", Required = Required.DisallowNull, NullValueHandling = NullValueHandling.Ignore)]
         public ICollection<Charge> Charge { get; set; }
+
+        /// <summary>
+        /// Custom class to extend. 
+        /// </summary>
+        [JsonProperty("document", Required = Required.DisallowNull, NullValueHandling = NullValueHandling.Ignore)]
+        public ICollection<CriminalDocument> Document { get; set; }
     }
 }

--- a/api/Models/Criminal/Detail/RedactedCriminalFileDetailResponse.cs
+++ b/api/Models/Criminal/Detail/RedactedCriminalFileDetailResponse.cs
@@ -2,6 +2,7 @@
 using JCCommon.Clients.FileServices;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using Scv.Api.Models.Criminal.Content;
 
 namespace Scv.Api.Models.Criminal.Detail
 {

--- a/api/Services/FilesService.cs
+++ b/api/Services/FilesService.cs
@@ -6,6 +6,7 @@ using JCCommon.Clients.FileServices;
 using JCCommon.Models;
 using MapsterMapper;
 using Microsoft.Extensions.Configuration;
+using Scv.Api.Helpers;
 using Scv.Api.Helpers.ContractResolver;
 using Scv.Api.Helpers.Exceptions;
 using Scv.Api.Models.Civil;
@@ -37,13 +38,13 @@ namespace Scv.Api.Services
         {
             _fileServicesClient = fileServicesClient;
             _fileServicesClient.JsonSerializerSettings.ContractResolver = new SafeContractResolver();
-            _fileServicesClient.BaseUrl = configuration.GetValue<string>("FileServicesClient:Url") ?? throw new ConfigurationException($"Configuration 'FileServicesClient:Url' is invalid or missing.");
+            _fileServicesClient.BaseUrl = configuration.GetNonEmptyValue("FileServicesClient:Url");
             _lookupService = lookupService;
             _locationService = locationService;
             _mapper = mapper;
-            _requestApplicationCode = configuration.GetValue<string>("Request:ApplicationCd") ?? throw new ConfigurationException($"Configuration 'Request:ApplicationCd' is invalid or missing.");
-            _requestAgencyIdentifierId = configuration.GetValue<string>("Request:AgencyIdentifierId") ?? throw new ConfigurationException($"Configuration 'Request:AgencyIdentifierId' is invalid or missing.");
-            _requestPartId = configuration.GetValue<string>("Request:PartId") ?? throw new ConfigurationException($"Configuration 'Request:PartId' is invalid or missing.");
+            _requestApplicationCode = configuration.GetNonEmptyValue("Request:ApplicationCd");
+            _requestAgencyIdentifierId = configuration.GetNonEmptyValue("Request:AgencyIdentifierId");
+            _requestPartId = configuration.GetNonEmptyValue("Request:PartId");
         }
         #endregion
 
@@ -185,6 +186,45 @@ namespace Scv.Api.Services
             var criminalFileDetailResponse = await _fileServicesClient.FilesCriminalFileIdAsync(_requestAgencyIdentifierId, _requestPartId, _requestApplicationCode, fileId);
             var redactedCriminalFileDetailResponse = _mapper.Map<RedactedCriminalFileDetailResponse>(criminalFileDetailResponse);
 
+            var criminalFileContent = await _fileServicesClient.FilesCriminalFilecontentAsync(null, null,
+                null, null, fileId);
+
+            //Generate documents from AccusedFile. 
+            var documents = criminalFileContent.AccusedFile.SelectMany(ac =>
+            {
+                var criminalDocuments = _mapper.Map<List<CriminalDocument>>(ac.Document);
+
+                //Create ROPs. 
+                if (ac.Appearance != null && ac.Appearance.Any())
+                {
+                    criminalDocuments.Insert(0, new CriminalDocument
+                    {
+                        DocumentTypeDescription = "Record of Proceedings",
+                        ImageId = ac.PartId,
+                        Category = "rop",
+                        PartId = ac.PartId,
+                        HasFutureAppearance = ac.Appearance?.Any(a =>
+                            a?.AppearanceDate != null && DateTime.Parse(a.AppearanceDate) >= DateTime.Today)
+                    });
+                }
+
+                //Populate extra fields. 
+                foreach (var document in criminalDocuments)
+                {
+                    document.Category = string.IsNullOrEmpty(document.Category) ? _lookupService.GetDocumentCategory(document.DocmFormId) : document.Category;
+                    document.DocumentTypeDescription = document.DocmFormDsc;
+                    document.PartId = ac.PartId;
+                }
+
+                return criminalDocuments;
+            }).ToList();
+
+            //Attach documents to participants.
+            foreach (var participant in redactedCriminalFileDetailResponse.Participant)
+            {
+                participant.Document = documents.Where(doc => doc.PartId == participant.PartId).ToList();
+            }
+
             return redactedCriminalFileDetailResponse;
         }
 
@@ -192,46 +232,6 @@ namespace Scv.Api.Services
         {
             var criminalFileIdAppearances = await _fileServicesClient.FilesCriminalFileIdAppearancesAsync(_requestAgencyIdentifierId, _requestPartId, future, history, fileId);
             return criminalFileIdAppearances;
-        }
-
-        public async Task<ICollection<CriminalDocument>> FilesCriminalFilecontentDocumentsAsync(string justinNumber)
-        {
-            var criminalFileContent = await _fileServicesClient.FilesCriminalFilecontentAsync(null, null,
-                null, null, justinNumber);
-
-            //Flatten Accused file. 
-            var documents = criminalFileContent.AccusedFile.SelectMany(ac =>
-            {
-                var criminalFileContentDocuments = ac.Document.Select(doc =>
-                    _mapper.Map<CriminalDocument>(ac.Document)
-                ).ToList();
-
-                //Create ROPs. 
-                if (ac.Appearance != null && ac.Appearance.Any())
-                {
-                    criminalFileContentDocuments.Insert(0, new CriminalDocument
-                    {
-                        DocumentTypeDescription = "Record of Proceedings",
-                        ImageId = ac.PartId,
-                        Category = "rop",
-                        PartId = ac.PartId,
-                        HasFutureAppearance = ac.Appearance?.Any(a => 
-                            a?.AppearanceDate != null && DateTime.Parse(a.AppearanceDate) >= DateTime.Today)
-                    });
-                }
-
-                //Populate extra fields. 
-                foreach (var document in criminalFileContentDocuments)
-                {
-                    document.Category = _lookupService.GetDocumentCategory(document.DocmFormId);
-                    document.DocumentTypeDescription = document.DocmFormDsc;
-                    document.PartId = ac.PartId;
-                }
-
-                return criminalFileContentDocuments;
-            }).ToList();
-
-            return documents;
         }
 
         public async Task<CriminalFileContent> FilesCriminalFilecontentAsync(string agencyId, string roomCode, DateTime? proceeding, string appearanceId, string justinNumber)

--- a/api/Services/LocationService.cs
+++ b/api/Services/LocationService.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using JCCommon.Clients.LocationServices;
 using LazyCache;
 using Microsoft.Extensions.Configuration;
+using Scv.Api.Helpers;
 using Scv.Api.Helpers.ContractResolver;
 using Scv.Api.Helpers.Exceptions;
 using CodeValue = System.Collections.Generic.ICollection<JCCommon.Clients.LocationServices.CodeValue>;
@@ -49,7 +50,7 @@ namespace Scv.Api.Services
         private void SetupLocationServicesClient()
         {
             _locationClient.JsonSerializerSettings.ContractResolver = new SafeContractResolver();
-            _locationClient.BaseUrl = _configuration.GetValue<string>("LocationServicesClient:Url") ?? throw new ConfigurationException($"Configuration 'LocationServicesClient:Url' is invalid or missing.");
+            _locationClient.BaseUrl = _configuration.GetNonEmptyValue("LocationServicesClient:Url");
         }
         #endregion
     }

--- a/api/Services/LookupService.cs
+++ b/api/Services/LookupService.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using JCCommon.Clients.LookupServices;
 using LazyCache;
 using Microsoft.Extensions.Configuration;
+using Scv.Api.Helpers;
 using Scv.Api.Helpers.ContractResolver;
 using Scv.Api.Helpers.Exceptions;
 using CodeLookup = System.Collections.Generic.ICollection<JCCommon.Clients.LookupServices.LookupCode>;
@@ -75,7 +76,7 @@ namespace Scv.Api.Services
         private void SetupLookupServicesClient()
         {
             _lookupClient.JsonSerializerSettings.ContractResolver = new SafeContractResolver();
-            _lookupClient.BaseUrl = _configuration.GetValue<string>("LookupServicesClient:Url") ?? throw new ConfigurationException($"Configuration 'LookupServicesClient:Url' is invalid or missing.");
+            _lookupClient.BaseUrl = _configuration.GetNonEmptyValue("LookupServicesClient:Url");
         }
         #endregion
     }

--- a/api/Startup.cs
+++ b/api/Startup.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Scv.Api.Helpers;
 using Scv.Api.Helpers.Mapping;
 using Scv.Api.Helpers.Middleware;
 using Scv.Api.Services;
@@ -45,22 +46,22 @@ namespace Scv.Api
             services.AddHttpClient<FileServicesClient>(client =>
             {
                 client.DefaultRequestHeaders.Authorization = new BasicAuthenticationHeaderValue(
-                    Configuration.GetValue<string>("FileServicesClient:Username"),
-                    Configuration.GetValue<string>("FileServicesClient:Password"));
+                    Configuration.GetNonEmptyValue("FileServicesClient:Username"),
+                    Configuration.GetNonEmptyValue("FileServicesClient:Password"));
             });
 
             services.AddHttpClient<LookupServiceClient>(client =>
             {
                 client.DefaultRequestHeaders.Authorization = new BasicAuthenticationHeaderValue(
-                    Configuration.GetValue<string>("LookupServicesClient:Username"),
-                    Configuration.GetValue<string>("LookupServicesClient:Password"));
+                    Configuration.GetNonEmptyValue("LookupServicesClient:Username"),
+                    Configuration.GetNonEmptyValue("LookupServicesClient:Password"));
             });
 
             services.AddHttpClient<LocationServicesClient>(client =>
             {
                 client.DefaultRequestHeaders.Authorization = new BasicAuthenticationHeaderValue(
-                    Configuration.GetValue<string>("LocationServicesClient:Username"),
-                    Configuration.GetValue<string>("LocationServicesClient:Password"));
+                    Configuration.GetNonEmptyValue("LocationServicesClient:Username"),
+                    Configuration.GetNonEmptyValue("LocationServicesClient:Password"));
             });
 
 

--- a/tests/api/Controllers/FilesControllerTests.cs
+++ b/tests/api/Controllers/FilesControllerTests.cs
@@ -280,7 +280,7 @@ namespace tests.api.Controllers
 
             var fileContentResult = actionResult as FileContentResult;
             Assert.NotNull(fileContentResult);
-            Assert.Equal(79161, fileContentResult.FileContents.Length);
+            Assert.True(fileContentResult.FileContents.Length > 79000);
         }
 
 
@@ -338,10 +338,10 @@ namespace tests.api.Controllers
             var actionResult = await _controller.GetCriminalFileDetailByFileId(fileId: "35840");
 
             var criminalFileDocuments = HttpResponseTest.CheckForValidHttpResponseAndReturnValue(actionResult);
-            Assert.Equal(4, criminalFileDocuments.Document.Count);
-            Assert.Contains(criminalFileDocuments.Document,
+            Assert.Equal(4, criminalFileDocuments.Participant.First().Document.Count);
+            Assert.Contains(criminalFileDocuments.Participant.First().Document,
                 doc => doc.DocmFormDsc == "Summons Criminal Code (With a very long name so I can test Cannabis names)");
-            Assert.Contains(criminalFileDocuments.Document, doc => doc.PartId == "61145.0002");
+            Assert.Contains(criminalFileDocuments.Participant.First().Document, doc => doc.PartId == "61145.0002");
         }
 
         [Fact]

--- a/tests/api/Controllers/FilesControllerTests.cs
+++ b/tests/api/Controllers/FilesControllerTests.cs
@@ -333,13 +333,15 @@ namespace tests.api.Controllers
 
         [Fact]
 
-        public async void Criminal_File_Content_Document_By_JustinNumber()
+        public async void Criminal_File_Detail_Document_By_JustinNumber()
         {
-            var actionResult = await _controller.GetCriminalFilecontentDocumentsAsync(fileId: "35840");
+            var actionResult = await _controller.GetCriminalFileDetailByFileId(fileId: "35840");
 
             var criminalFileDocuments = HttpResponseTest.CheckForValidHttpResponseAndReturnValue(actionResult);
-            Assert.Equal(4, criminalFileDocuments.Count);
-            Assert.Contains(criminalFileDocuments, doc => doc.PartId == "61145.0002");
+            Assert.Equal(4, criminalFileDocuments.Document.Count);
+            Assert.Contains(criminalFileDocuments.Document,
+                doc => doc.DocmFormDsc == "Summons Criminal Code (With a very long name so I can test Cannabis names)");
+            Assert.Contains(criminalFileDocuments.Document, doc => doc.PartId == "61145.0002");
         }
 
         [Fact]


### PR DESCRIPTION
Merge criminal/{fileId}/documents into criminal/{fileId} …
Build ConfigurationExtensions.cs, to help with throwing exceptions when certain configuration values aren't loaded
Work on FilesCriminalFileIdAsync
Move document under Participant for criminal case