### PR TITLE
CriminalAppearanceDetail improvements

### DIFF
--- a/api/Controllers/FilesController.cs
+++ b/api/Controllers/FilesController.cs
@@ -45,7 +45,8 @@ namespace Scv.Api.Controllers
         /// <summary>
         /// Provides facilities for performing a civil file search.
         /// </summary>
-        /// <param name="fcq">FileCivilQuery object with many parameters</param>
+        /// <param name="fcq">FileCivilQuery object with many parameters - Search Modes: FILENO = 0, PARTNAME = 1, CROWN = 2, JUSTINNO = 3, PHYSID = 4</param>
+        /// 
         /// <returns>FileSearchResponse</returns>
         [HttpPost]
         [Route("civil/search")]
@@ -65,6 +66,8 @@ namespace Scv.Api.Controllers
         public async Task<ActionResult<RedactedCivilFileDetailResponse>> GetCivilFileDetailByFileId(string fileId)
         {
             var civilFileDetailResponse = await _filesService.CivilFileIdAsync(fileId);
+            if (civilFileDetailResponse?.PhysicalFileId == null)
+                throw new NotFoundException("Couldn't find civil file with this id.");
             return Ok(civilFileDetailResponse);
         }
 
@@ -78,8 +81,10 @@ namespace Scv.Api.Controllers
         [Route("civil/{fileId}/appearance-detail/{appearanceId}")]
         public async Task<ActionResult<CivilAppearanceDetail>> GetCivilAppearanceDetails(string fileId, string appearanceId)
         {
-            var res = await _filesService.CivilDetailedAppearanceAsync(fileId, appearanceId);
-            return Ok(res);
+            var civilAppearanceDetail = await _filesService.CivilDetailedAppearanceAsync(fileId, appearanceId);
+            if (civilAppearanceDetail == null)
+                throw new NotFoundException("Couldn't find appearance detail with the provided file id and appearance id.");
+            return Ok(civilAppearanceDetail);
         }
 
         /// <summary>
@@ -150,18 +155,17 @@ namespace Scv.Api.Controllers
         }
 
         /// <summary>
-        /// Gets detailed information regarding an appearance given criminal file id, appearance id, participant id and sequence number.
+        /// Gets detailed information regarding an appearance given criminal file id, appearance id, participant id.
         /// </summary>
         /// <param name="fileId"></param>
         /// <param name="appearanceId"></param>
         /// <param name="partId"></param>
-        /// <param name="profSeqNo"></param>
         /// <returns>CriminalAppearanceDetail</returns>
         [HttpGet]
-        [Route("criminal/{fileId}/appearance-detail/{appearanceId}/{partId}/{profSeqNo}")]
-        public async Task<ActionResult<CriminalAppearanceDetail>> GetCriminalAppearanceDetails(string fileId, string appearanceId, string partId, string profSeqNo)
+        [Route("criminal/{fileId}/appearance-detail/{appearanceId}/{partId}")]
+        public async Task<ActionResult<CriminalAppearanceDetail>> GetCriminalAppearanceDetails(string fileId, string appearanceId, string partId)
         {
-            var appearanceDetail = await _filesService.CriminalAppearanceDetailAsync(fileId, appearanceId, partId, profSeqNo);
+            var appearanceDetail = await _filesService.CriminalAppearanceDetailAsync(fileId, appearanceId, partId);
             if (appearanceDetail == null)
                 throw new NotFoundException("Couldn't find appearance details with the provided parameters.");
             return Ok(appearanceDetail);

--- a/api/Controllers/FilesController.cs
+++ b/api/Controllers/FilesController.cs
@@ -150,7 +150,7 @@ namespace Scv.Api.Controllers
         }
 
         /// <summary>
-        /// Gets detailed information regarding an appearance given criminal file id and appearance id.
+        /// Gets detailed information regarding an appearance given criminal file id, appearance id, participant id and sequence number.
         /// </summary>
         /// <param name="fileId"></param>
         /// <param name="appearanceId"></param>
@@ -158,12 +158,12 @@ namespace Scv.Api.Controllers
         /// <param name="profSeqNo"></param>
         /// <returns>CriminalAppearanceDetail</returns>
         [HttpGet]
-        [Route("criminal/{fileId}/appearance-detail/{appearanceId}")]
-        public async Task<ActionResult<CriminalAppearanceDetail>> GetCriminalAppearanceDetails(string fileId, string appearanceId, string partId = null, string profSeqNo = null)
+        [Route("criminal/{fileId}/appearance-detail/{appearanceId}/{partId}/{profSeqNo}")]
+        public async Task<ActionResult<CriminalAppearanceDetail>> GetCriminalAppearanceDetails(string fileId, string appearanceId, string partId, string profSeqNo)
         {
             var appearanceDetail = await _filesService.CriminalAppearanceDetailAsync(fileId, appearanceId, partId, profSeqNo);
             if (appearanceDetail == null)
-                throw new NotFoundException("Couldn't find appearance details with this id.");
+                throw new NotFoundException("Couldn't find appearance details with the provided parameters.");
             return Ok(appearanceDetail);
         }
 

--- a/api/Controllers/FilesController.cs
+++ b/api/Controllers/FilesController.cs
@@ -51,7 +51,7 @@ namespace Scv.Api.Controllers
         [Route("civil/search")]
         public async Task<ActionResult<FileSearchResponse>> FilesCivilSearchAsync(FilesCivilQuery fcq)
         {
-            var fileSearchResponse = await _filesService.FilesCivilAsync(fcq);
+            var fileSearchResponse = await _filesService.CivilSearchAsync(fcq);
             return Ok(fileSearchResponse);
         }
 
@@ -64,7 +64,7 @@ namespace Scv.Api.Controllers
         [Route("civil/{fileId}")]
         public async Task<ActionResult<RedactedCivilFileDetailResponse>> GetCivilFileDetailByFileId(string fileId)
         {
-            var civilFileDetailResponse = await _filesService.FilesCivilFileIdAsync(fileId);
+            var civilFileDetailResponse = await _filesService.CivilFileIdAsync(fileId);
             return Ok(civilFileDetailResponse);
         }
 
@@ -78,7 +78,7 @@ namespace Scv.Api.Controllers
         [Route("civil/{fileId}/appearance-detail/{appearanceId}")]
         public async Task<ActionResult<CivilAppearanceDetail>> GetCivilAppearanceDetails(string fileId, string appearanceId)
         {
-            var res = await _filesService.FilesCivilDetailedAppearanceAsync(fileId, appearanceId);
+            var res = await _filesService.CivilDetailedAppearanceAsync(fileId, appearanceId);
             return Ok(res);
         }
 
@@ -92,7 +92,7 @@ namespace Scv.Api.Controllers
         [Route("civil/court-summary-report/{appearanceId}/{fileNameAndExtension}")]
         public async Task<IActionResult> GetCivilCourtSummaryReport(string appearanceId, string fileNameAndExtension)
         {
-            var justinReportResponse = await _filesService.FilesCivilCourtsummaryreportAsync(appearanceId, JustinReportName.CEISR035);
+            var justinReportResponse = await _filesService.CivilCourtSummaryReportAsync(appearanceId, JustinReportName.CEISR035);
 
             if (justinReportResponse.ReportContent == null || justinReportResponse.ReportContent.Length <= 0)
                 throw new NotFoundException("Couldn't find CSR with this appearance id.");
@@ -113,7 +113,7 @@ namespace Scv.Api.Controllers
         [Route("civil/file-content")]
         public async Task<ActionResult<CivilFileContent>> GetCivilFileContent(string agencyId = null, string roomCode = null, DateTime? proceeding = null, string appearanceId = null, string physicalFileId = "")
         {
-            var civilFileContent = await _filesService.FilesCivilFilecontentAsync(agencyId, roomCode, proceeding, appearanceId, physicalFileId);
+            var civilFileContent = await _filesService.CivilFileContentAsync(agencyId, roomCode, proceeding, appearanceId, physicalFileId);
             return Ok(civilFileContent);
         }
 
@@ -130,7 +130,7 @@ namespace Scv.Api.Controllers
         [Route("criminal/search")]
         public async Task<ActionResult<FileSearchResponse>> FilesCriminalSearchAsync(FilesCriminalQuery fcq)
         {
-            var fileSearchResponse = await _filesService.FilesCriminalAsync(fcq);
+            var fileSearchResponse = await _filesService.CriminalSearchAsync(fcq);
             return Ok(fileSearchResponse);
         }
 
@@ -143,7 +143,7 @@ namespace Scv.Api.Controllers
         [Route("criminal/{fileId}")]
         public async Task<ActionResult<RedactedCriminalFileDetailResponse>> GetCriminalFileDetailByFileId(string fileId)
         {
-            var redactedCriminalFileDetailResponse = await _filesService.FilesCriminalFileIdAsync(fileId);
+            var redactedCriminalFileDetailResponse = await _filesService.CriminalFileIdAsync(fileId);
             if (redactedCriminalFileDetailResponse?.JustinNo == null)
                 throw new NotFoundException("Couldn't find criminal file with this id.");
             return Ok(redactedCriminalFileDetailResponse);
@@ -161,8 +161,10 @@ namespace Scv.Api.Controllers
         [Route("criminal/{fileId}/appearance-detail/{appearanceId}")]
         public async Task<ActionResult<CriminalAppearanceDetail>> GetCriminalAppearanceDetails(string fileId, string appearanceId, string partId = null, string profSeqNo = null)
         {
-            var res = await _filesService.FilesCriminalAppearanceDetailAsync(fileId, appearanceId, partId, profSeqNo);
-            return Ok(res);
+            var appearanceDetail = await _filesService.CriminalAppearanceDetailAsync(fileId, appearanceId, partId, profSeqNo);
+            if (appearanceDetail == null)
+                throw new NotFoundException("Couldn't find appearance details with this id.");
+            return Ok(appearanceDetail);
         }
 
         /// <summary>
@@ -178,7 +180,7 @@ namespace Scv.Api.Controllers
         [Route("criminal/file-content")]
         public async Task<ActionResult<CriminalFileContent>> GetCriminalFileContent(string agencyId = null, string roomCode = null, DateTime? proceeding = null, string appearanceId = null, string justinNumber = null)
         {
-            var criminalFileContent = await _filesService.FilesCriminalFilecontentAsync(agencyId, roomCode, proceeding, appearanceId, justinNumber);
+            var criminalFileContent = await _filesService.CriminalFileContentAsync(agencyId, roomCode, proceeding, appearanceId, justinNumber);
             return Ok(criminalFileContent);
         }
 
@@ -195,7 +197,7 @@ namespace Scv.Api.Controllers
         [Route("criminal/record-of-proceedings/{partId}/{fileNameAndExtension}")]
         public async Task<IActionResult> GetRecordsOfProceeding(string partId, string fileNameAndExtension, string profSequenceNumber, CourtLevelCd courtLevelCode, CourtClassCd courtClassCode)
         {
-            var recordsOfProceeding = await _filesService.FilesRecordOfProceedingsAsync(partId, profSequenceNumber, courtLevelCode, courtClassCode);
+            var recordsOfProceeding = await _filesService.RecordOfProceedingsAsync(partId, profSequenceNumber, courtLevelCode, courtClassCode);
 
             if (recordsOfProceeding.B64Content == null || recordsOfProceeding.B64Content.Length <= 0)
                 throw new NotFoundException("Couldn't find ROP with this part id.");
@@ -218,7 +220,7 @@ namespace Scv.Api.Controllers
         [Route("court-list")]
         public async Task<ActionResult<CourtList>> GetCourtList(string agencyId, string roomCode, DateTime? proceeding, string divisionCode, string fileNumber)
         {
-            var courtList = await _filesService.FilesCourtlistAsync(agencyId, roomCode, proceeding, divisionCode,
+            var courtList = await _filesService.CourtListAsync(agencyId, roomCode, proceeding, divisionCode,
                 fileNumber);
             return Ok(courtList);
         }
@@ -234,7 +236,7 @@ namespace Scv.Api.Controllers
         [Route("document/{documentId}/{fileNameAndExtension}")]
         public async Task<IActionResult> GetDocument(string documentId, string fileNameAndExtension, bool isCriminal = false)
         {
-            var documentResponse = await _filesService.FilesDocumentAsync(documentId, isCriminal);
+            var documentResponse = await _filesService.DocumentAsync(documentId, isCriminal);
 
             if (documentResponse.B64Content == null || documentResponse.B64Content.Length <= 0)
                 throw new NotFoundException("Couldn't find document with this id.");

--- a/api/Helpers/StringExtensions.cs
+++ b/api/Helpers/StringExtensions.cs
@@ -3,5 +3,6 @@
     public static class StringExtensions
     {
         public static string EnsureEndingForwardSlash(this string target) => target.EndsWith("/") ? target : $"{target}/";
+        public static string ReturnNullIfNullOrEmpty(string target) => string.IsNullOrEmpty(target) ? null : target;
     }
 }

--- a/api/Helpers/StringExtensions.cs
+++ b/api/Helpers/StringExtensions.cs
@@ -3,6 +3,12 @@
     public static class StringExtensions
     {
         public static string EnsureEndingForwardSlash(this string target) => target.EndsWith("/") ? target : $"{target}/";
-        public static string ReturnNullIfNullOrEmpty(string target) => string.IsNullOrEmpty(target) ? null : target;
+        public static string ReturnNullIfEmpty(this string target) => string.IsNullOrEmpty(target) ? null : target;
+
+        public static string ConvertNameLastCommaFirstToFirstLast(this string name)
+        {
+            var names = name?.Split(",");
+            return names?.Length == 2 ? $"{names[1].Trim()} {names[0].Trim()}" : name;
+        }
     }
 }

--- a/api/Models/Civil/AppearanceDetail/CivilAppearanceDocument.cs
+++ b/api/Models/Civil/AppearanceDetail/CivilAppearanceDocument.cs
@@ -15,11 +15,12 @@ namespace Scv.Api.Models.Civil.AppearanceDetail
     {
         public string Category { get; set; }
         public string DocumentTypeDescription { get; set; }
-
         /// <summary>
         /// Modified class, hides fields.
         /// </summary>
         public new ICollection<CivilIssue> Issue { get; set; }
+        public string AppearanceResultCd { get; set; }
+        public string AppearanceResultDesc { get; set; }
 
         /// <summary>
         /// Exclude this property, even though it exists in CvfcDocument3.

--- a/api/Models/Criminal/AppearanceDetail/Adjudicator.cs
+++ b/api/Models/Criminal/AppearanceDetail/Adjudicator.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Scv.Api.Models.Criminal.AppearanceDetail
+{
+    public class Adjudicator
+    {
+        public string Name { get; set; }
+        public string PartyAppearanceMethod { get; set; }
+    }
+}

--- a/api/Models/Criminal/AppearanceDetail/Adjudicator.cs
+++ b/api/Models/Criminal/AppearanceDetail/Adjudicator.cs
@@ -1,15 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace Scv.Api.Models.Criminal.AppearanceDetail
+﻿namespace Scv.Api.Models.Criminal.AppearanceDetail
 {
     public class Adjudicator
     {
-        public string Name { get; set; }
+        public string FullName { get; set; }
         public string PartId { get; set; }
         public string PartyAppearanceMethod { get; set; }
         public string PartyAppearanceMethodDesc { get; set; }
+        public string AttendanceMethodCd { get; set; }
+        public string AttendanceMethodDesc { get; set; }
     }
 }

--- a/api/Models/Criminal/AppearanceDetail/Adjudicator.cs
+++ b/api/Models/Criminal/AppearanceDetail/Adjudicator.cs
@@ -8,6 +8,8 @@ namespace Scv.Api.Models.Criminal.AppearanceDetail
     public class Adjudicator
     {
         public string Name { get; set; }
+        public string PartId { get; set; }
         public string PartyAppearanceMethod { get; set; }
+        public string PartyAppearanceMethodDesc { get; set; }
     }
 }

--- a/api/Models/Criminal/AppearanceDetail/CriminalAccused.cs
+++ b/api/Models/Criminal/AppearanceDetail/CriminalAccused.cs
@@ -9,5 +9,7 @@ namespace Scv.Api.Models.Criminal.AppearanceDetail
         public string PartId { get; set; }
         public string PartyAppearanceMethod { get; set; }
         public string PartyAppearanceMethodDesc { get; set; }
+        public string AttendanceMethodCd { get; set; }
+        public string AttendanceMethodDesc { get; set; }
     }
 }

--- a/api/Models/Criminal/AppearanceDetail/CriminalAccused.cs
+++ b/api/Models/Criminal/AppearanceDetail/CriminalAccused.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using JCCommon.Clients.FileServices;
+
+namespace Scv.Api.Models.Criminal.AppearanceDetail
+{
+    public class CriminalAccused
+    {
+        public string FullName { get; set; }
+        public ICollection<CriminalAppearanceMethod> AppearanceMethods { get; set; }
+    }
+}

--- a/api/Models/Criminal/AppearanceDetail/CriminalAccused.cs
+++ b/api/Models/Criminal/AppearanceDetail/CriminalAccused.cs
@@ -6,6 +6,8 @@ namespace Scv.Api.Models.Criminal.AppearanceDetail
     public class CriminalAccused
     {
         public string FullName { get; set; }
-        public ICollection<CriminalAppearanceMethod> AppearanceMethods { get; set; }
+        public string PartId { get; set; }
+        public string PartyAppearanceMethod { get; set; }
+        public string PartyAppearanceMethodDesc { get; set; }
     }
 }

--- a/api/Models/Criminal/AppearanceDetail/CriminalAppearanceDetail.cs
+++ b/api/Models/Criminal/AppearanceDetail/CriminalAppearanceDetail.cs
@@ -25,7 +25,7 @@ namespace Scv.Api.Models.Criminal.AppearanceDetail
         /// <summary>
         /// Extended CriminalAppearanceMethod object.
         /// </summary>
-        public ICollection<CfcPartyAppearanceMethod> PartyAppearanceMethods { get; set; }
+        public ICollection<CriminalAppearanceMethod> AppearanceMethods { get; set; }
         public string EstimatedTimeHour { get; set; }
         public string EstimatedTimeMin { get; set; }
     }

--- a/api/Models/Criminal/AppearanceDetail/CriminalAppearanceDetail.cs
+++ b/api/Models/Criminal/AppearanceDetail/CriminalAppearanceDetail.cs
@@ -21,5 +21,8 @@ namespace Scv.Api.Models.Criminal.AppearanceDetail
         public ICollection<CriminalAppearanceMethod> AppearanceMethods { get; set; }
 
         public JustinCounsel JustinCounsel { get; set; }
+
+        //Temp.
+        public ClCriminalCourtList CourtList { get; set; }
     }
 }

--- a/api/Models/Criminal/AppearanceDetail/CriminalAppearanceDetail.cs
+++ b/api/Models/Criminal/AppearanceDetail/CriminalAppearanceDetail.cs
@@ -6,7 +6,9 @@ namespace Scv.Api.Models.Criminal.AppearanceDetail
     public class CriminalAppearanceDetail
     {
         public string JustinNo { get; set; }
+        public string AppearanceId { get; set; }
         public string PartId { get; set; }
+        public string AgencyId { get; set; }
         public string ProfSeqNo { get; set; }
         public string CourtRoomCd { get; set; }
         public string FileNumberTxt { get; set; }

--- a/api/Models/Criminal/AppearanceDetail/CriminalAppearanceDetail.cs
+++ b/api/Models/Criminal/AppearanceDetail/CriminalAppearanceDetail.cs
@@ -5,11 +5,18 @@ namespace Scv.Api.Models.Criminal.AppearanceDetail
 {
     public class CriminalAppearanceDetail
     {
-        public string AppearanceNote { get; set; }
         public string JustinNo { get; set; }
         public string PartId { get; set; }
         public string ProfSeqNo { get; set; }
-
+        public string CourtRoomCd { get; set; }
+        public string FileNumberTxt { get; set; }
+        public string AppearanceDt { get; set; }
+        public JustinCounsel JustinCounsel { get; set; }
+        public CriminalAccused Accused { get; set; }
+        public Prosecutor Prosecutor { get; set; }
+        public Adjudicator Adjudicator { get; set; }
+        public string JudgesRecommendation { get; set; }
+        public string AppearanceNote { get; set; }
         /// <summary>
         /// Extended CriminalAppearanceCount object.
         /// </summary>
@@ -18,11 +25,8 @@ namespace Scv.Api.Models.Criminal.AppearanceDetail
         /// <summary>
         /// Extended CriminalAppearanceMethod object.
         /// </summary>
-        public ICollection<CriminalAppearanceMethod> AppearanceMethods { get; set; }
-
-        public JustinCounsel JustinCounsel { get; set; }
-
-        //Temp.
-        public ClCriminalCourtList CourtList { get; set; }
+        public ICollection<CfcPartyAppearanceMethod> PartyAppearanceMethods { get; set; }
+        public string EstimatedTimeHour { get; set; }
+        public string EstimatedTimeMin { get; set; }
     }
 }

--- a/api/Models/Criminal/AppearanceDetail/JustinCounsel.cs
+++ b/api/Models/Criminal/AppearanceDetail/JustinCounsel.cs
@@ -12,5 +12,6 @@
         public string CounselPartId { get; set; }
         public string CounselRelatedRepTypeCd { get; set; }
         public string CounselRrepId { get; set; }
+        public string AppearanceMethod { get; set; }
     }
 }

--- a/api/Models/Criminal/AppearanceDetail/JustinCounsel.cs
+++ b/api/Models/Criminal/AppearanceDetail/JustinCounsel.cs
@@ -12,6 +12,7 @@
         public string CounselPartId { get; set; }
         public string CounselRelatedRepTypeCd { get; set; }
         public string CounselRrepId { get; set; }
-        public string AppearanceMethod { get; set; }
+        public string PartyAppearanceMethod { get; set; }
+        public string PartyAppearanceMethodDesc { get; set; }
     }
 }

--- a/api/Models/Criminal/AppearanceDetail/JustinCounsel.cs
+++ b/api/Models/Criminal/AppearanceDetail/JustinCounsel.cs
@@ -14,5 +14,7 @@
         public string CounselRrepId { get; set; }
         public string PartyAppearanceMethod { get; set; }
         public string PartyAppearanceMethodDesc { get; set; }
+        public string AttendanceMethodCd { get; set; }
+        public string AttendanceMethodDesc { get; set; }
     }
 }

--- a/api/Models/Criminal/AppearanceDetail/Prosecutor.cs
+++ b/api/Models/Criminal/AppearanceDetail/Prosecutor.cs
@@ -8,6 +8,8 @@ namespace Scv.Api.Models.Criminal.AppearanceDetail
     public class Prosecutor
     {
         public string Name { get; set; }
+        public string PartId { get; set; }
         public string PartyAppearanceMethod { get; set; }
+        public string PartyAppearanceMethodDesc { get; set; }
     }
 }

--- a/api/Models/Criminal/AppearanceDetail/Prosecutor.cs
+++ b/api/Models/Criminal/AppearanceDetail/Prosecutor.cs
@@ -7,9 +7,11 @@ namespace Scv.Api.Models.Criminal.AppearanceDetail
 {
     public class Prosecutor
     {
-        public string Name { get; set; }
+        public string FullName { get; set; }
         public string PartId { get; set; }
         public string PartyAppearanceMethod { get; set; }
         public string PartyAppearanceMethodDesc { get; set; }
+        public string AttendanceMethodCd { get; set; }
+        public string AttendanceMethodDesc { get; set; }
     }
 }

--- a/api/Models/Criminal/AppearanceDetail/Prosecutor.cs
+++ b/api/Models/Criminal/AppearanceDetail/Prosecutor.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Scv.Api.Models.Criminal.AppearanceDetail
+{
+    public class Prosecutor
+    {
+        public string Name { get; set; }
+        public string PartyAppearanceMethod { get; set; }
+    }
+}

--- a/api/Services/LocationService.cs
+++ b/api/Services/LocationService.cs
@@ -62,8 +62,7 @@ namespace Scv.Api.Services
 
         private async Task<T> GetDataFromCache<T>(string key, Func<Task<T>> fetchFunction)
         {
-            return await _cache.GetOrAddAsync(key,
-                async () => await fetchFunction.Invoke());
+            return await _cache.GetOrAddAsync(key, async () => await fetchFunction.Invoke());
         }
 
         private string FindLongDescriptionFromCode(CodeValue lookupCodes, string code) => lookupCodes.FirstOrDefault(lookupCode => lookupCode.Code == code)?.LongDesc;

--- a/api/Services/LookupService.cs
+++ b/api/Services/LookupService.cs
@@ -45,25 +45,9 @@ namespace Scv.Api.Services
 
         #region Collection Methods
 
-        public async Task<CodeLookup> GetCriminalAppearanceMethodsAccused()
+        public async Task<CodeLookup> GetCriminalPartyAttendanceTypes()
         {
-            return await GetDataFromCache(
-                "CriminalAppearanceMethodsAccused",
-                async () => await _lookupClient.CodesCriminalAppearancePartyAppearanceMethodsAccusedAsync());
-        }
-
-        public async Task<CodeLookup> GetCriminalAppearancesMethodsAccusedCounsel()
-        {
-            return await GetDataFromCache(
-                "CriminalAppearancesMethodsAccusedCounsel",
-                async () => await _lookupClient.CodesCriminalAppearancePartyAppearanceMethodsAccusedCounselAsync());
-        }
-
-        public async Task<CodeLookup> GetCriminalAppearanceMethodsCrown()
-        {
-            return await GetDataFromCache(
-                "CriminalAppearanceMethodsCrown",
-                async () => await _lookupClient.CodesCriminalAppearancePartyAppearanceMethodsCrownAsync());
+            return await GetDataFromCache("CriminalPartyAttendanceTypes",async () => await _lookupClient.CodesCriminalAppearancePartyAttendanceTypesAsync());
         }
 
         public async Task<CodeLookup> GetAgencyLocations()
@@ -176,12 +160,21 @@ namespace Scv.Api.Services
         #endregion Collection Methods
 
         #region Lookup Methods
-        
-        public async Task<string> GetCriminalAppearanceMethodCrown(string code) => FindShortDescriptionFromCode(await GetCriminalAppearanceMethodsCrown(), code);
+   
+        public async Task<string> GetPartyAttendanceType(string targetCode)
+        {
+            if (targetCode == null)
+                return null;
+            var codes = await GetCriminalPartyAttendanceTypes();
+            if (targetCode == "RA") return FindShortDescriptionFromCode(codes, targetCode);
 
-        public async Task<string> GetCriminalAppearanceMethodAccused(string code) => FindShortDescriptionFromCode(await GetCriminalAppearanceMethodsAccused(), code);
-
-        public async Task<string> GetCriminalAppearanceMethodAccusedCounsel(string code) => FindShortDescriptionFromCode(await GetCriminalAppearancesMethodsAccusedCounsel(), code);
+            var result = "";
+            foreach (var character in targetCode.Select(b => b))
+            {
+                result += $"{FindShortDescriptionFromCode(codes, character.ToString())} ";
+            }
+            return result.Trim();
+        }
 
         public async Task<string> GetAgencyLocationDescription(string code) => FindLongDescriptionFromCode(await GetAgencyLocations(), code);
 

--- a/api/Services/LookupService.cs
+++ b/api/Services/LookupService.cs
@@ -45,47 +45,143 @@ namespace Scv.Api.Services
 
         #region Collection Methods
 
-        public async Task<CodeLookup> GetAgencyLocations() => await GetDataFromCache("AgencyLocations", async () => await _lookupClient.CodesAgencyLocationsAsync());
+        public async Task<CodeLookup> GetCriminalAppearanceMethodsAccused()
+        {
+            return await GetDataFromCache(
+                "CriminalAppearanceMethodsAccused",
+                async () => await _lookupClient.CodesCriminalAppearancePartyAppearanceMethodsAccusedAsync());
+        }
 
-        public async Task<CodeLookup> GetCivilAppearanceReasons() => await GetDataFromCache("CivilAppearanceReasons", async () => await _lookupClient.CodesCivilAppearanceReasonsAsync());
+        public async Task<CodeLookup> GetCriminalAppearancesMethodsAccusedCounsel()
+        {
+            return await GetDataFromCache(
+                "CriminalAppearancesMethodsAccusedCounsel",
+                async () => await _lookupClient.CodesCriminalAppearancePartyAppearanceMethodsAccusedCounselAsync());
+        }
 
-        public async Task<CodeLookup> GetCivilAppearanceResults() => await GetDataFromCache("CivilAppearanceResults", async () => await _lookupClient.CodesCivilAppearanceResultsAsync());
+        public async Task<CodeLookup> GetCriminalAppearanceMethodsCrown()
+        {
+            return await GetDataFromCache(
+                "CriminalAppearanceMethodsCrown",
+                async () => await _lookupClient.CodesCriminalAppearancePartyAppearanceMethodsCrownAsync());
+        }
 
-        public async Task<CodeLookup> GetCivilAppearanceStatuses() => await GetDataFromCache("CivilAppearanceStatuses", async () => await _lookupClient.CodesCivilAppearanceStatusesAsync());
-        
-        public async Task<CodeLookup> GetComplexityTypeDescription() => await GetDataFromCache("ComplexityTypes", async() => await _lookupClient.CodesFileComplexitiesAsync());
+        public async Task<CodeLookup> GetAgencyLocations()
+        {
+            return await GetDataFromCache("AgencyLocations",
+                async () => await _lookupClient.CodesAgencyLocationsAsync());
+        }
 
-        public async Task<CodeLookup> GetCriminalAppearanceReasons() => await GetDataFromCache("CriminalAppearanceReasons", async () => await _lookupClient.CodesCriminalAppearanceReasonsAsync());
+        public async Task<CodeLookup> GetCivilAppearanceReasons()
+        {
+            return await GetDataFromCache("CivilAppearanceReasons",
+                async () => await _lookupClient.CodesCivilAppearanceReasonsAsync());
+        }
 
-        public async Task<CodeLookup> GetCriminalAppearanceResults() => await GetDataFromCache("CriminalAppearanceResults", async () => await _lookupClient.CodesCriminalAppearanceResultsAsync());
+        public async Task<CodeLookup> GetCivilAppearanceResults()
+        {
+            return await GetDataFromCache("CivilAppearanceResults",
+                async () => await _lookupClient.CodesCivilAppearanceResultsAsync());
+        }
 
-        public async Task<CodeLookup> GetCriminalAppearanceStatuses() => await GetDataFromCache("CriminalAppearanceStatuses", async () => await _lookupClient.CodesCriminalAppearanceStatusesAsync());
+        public async Task<CodeLookup> GetCivilAppearanceStatuses()
+        {
+            return await GetDataFromCache("CivilAppearanceStatuses",
+                async () => await _lookupClient.CodesCivilAppearanceStatusesAsync());
+        }
 
-        public async Task<CodeLookup> GetAppearanceDurations() => await GetDataFromCache("AppearanceDurations", async () => await _lookupClient.CodesCriminalAppearanceDurationAsync());
+        public async Task<CodeLookup> GetComplexityTypeDescription()
+        {
+            return await GetDataFromCache("ComplexityTypes",
+                async () => await _lookupClient.CodesFileComplexitiesAsync());
+        }
 
-        public async Task<CodeLookup> GetFindings() => await GetDataFromCache("Findings", async () => await _lookupClient.CodesFindingsAsync());
+        public async Task<CodeLookup> GetCriminalAppearanceReasons()
+        {
+            return await GetDataFromCache("CriminalAppearanceReasons",
+                async () => await _lookupClient.CodesCriminalAppearanceReasonsAsync());
+        }
 
-        public async Task<CodeLookup> GetCourtClass() => await GetDataFromCache("CourtClasses", async () => await _lookupClient.CodesCourtClassesAsync());
+        public async Task<CodeLookup> GetCriminalAppearanceResults()
+        {
+            return await GetDataFromCache("CriminalAppearanceResults",
+                async () => await _lookupClient.CodesCriminalAppearanceResultsAsync());
+        }
 
-        public async Task<CodeLookup> GetCourtLevel() => await GetDataFromCache("CourtLevels", async () => await _lookupClient.CodesCourtLevelsAsync());
+        public async Task<CodeLookup> GetCriminalAppearanceStatuses()
+        {
+            return await GetDataFromCache("CriminalAppearanceStatuses",
+                async () => await _lookupClient.CodesCriminalAppearanceStatusesAsync());
+        }
 
-        public async Task<CodeLookup> GetCriminalAssets() => await GetDataFromCache("CriminalAssets", async () => await _lookupClient.CodesCriminalAssetsAsync());
+        public async Task<CodeLookup> GetAppearanceDurations()
+        {
+            return await GetDataFromCache("AppearanceDurations",
+                async () => await _lookupClient.CodesCriminalAppearanceDurationAsync());
+        }
 
-        public async Task<CodeLookup> GetDocuments() => await GetDataFromCache("Documents", async () => await _lookupClient.CodesDocumentsAsync());
+        public async Task<CodeLookup> GetFindings()
+        {
+            return await GetDataFromCache("Findings", async () => await _lookupClient.CodesFindingsAsync());
+        }
 
-        public async Task<CodeLookup> GetRoles() => await GetDataFromCache("Roles", async () => await _lookupClient.CodesRolesAsync());
+        public async Task<CodeLookup> GetCourtClass()
+        {
+            return await GetDataFromCache("CourtClasses", async () => await _lookupClient.CodesCourtClassesAsync());
+        }
 
-        public async Task<CodeLookup> GetParticipantRoles() => await GetDataFromCache("ParticipantRoles", async () => await _lookupClient.CodesParticipantRolesAsync());
+        public async Task<CodeLookup> GetCourtLevel()
+        {
+            return await GetDataFromCache("CourtLevels", async () => await _lookupClient.CodesCourtLevelsAsync());
+        }
 
-        public async Task<CodeLookup> GetWitnessRoles() => await GetDataFromCache("WitnessRoles", async () => await _lookupClient.CodesWitnessRolesAsync());
+        public async Task<CodeLookup> GetCriminalAssets()
+        {
+            return await GetDataFromCache("CriminalAssets", async () => await _lookupClient.CodesCriminalAssetsAsync());
+        }
 
-        public async Task<CodeLookup> GetHearingRestrictions() => await GetDataFromCache("HearingRestrictions", async () => await _lookupClient.CodesHearingRestrictionsAsync());
+        public async Task<CodeLookup> GetDocuments()
+        {
+            return await GetDataFromCache("Documents", async () => await _lookupClient.CodesDocumentsAsync());
+        }
 
-        public async Task<CodeLookup> GetCriminalSentences() => await GetDataFromCache("CriminalSentences", async () => await _lookupClient.CodesCriminalSentencesAsync());
+        public async Task<CodeLookup> GetRoles()
+        {
+            return await GetDataFromCache("Roles", async () => await _lookupClient.CodesRolesAsync());
+        }
+
+        public async Task<CodeLookup> GetParticipantRoles()
+        {
+            return await GetDataFromCache("ParticipantRoles",
+                async () => await _lookupClient.CodesParticipantRolesAsync());
+        }
+
+        public async Task<CodeLookup> GetWitnessRoles()
+        {
+            return await GetDataFromCache("WitnessRoles", async () => await _lookupClient.CodesWitnessRolesAsync());
+        }
+
+        public async Task<CodeLookup> GetHearingRestrictions()
+        {
+            return await GetDataFromCache("HearingRestrictions",
+                async () => await _lookupClient.CodesHearingRestrictionsAsync());
+        }
+
+        public async Task<CodeLookup> GetCriminalSentences()
+        {
+            return await GetDataFromCache("CriminalSentences",
+                async () => await _lookupClient.CodesCriminalSentencesAsync());
+        }
 
         #endregion Collection Methods
 
         #region Lookup Methods
+        
+        public async Task<string> GetCriminalAppearanceMethodCrown(string code) => FindShortDescriptionFromCode(await GetCriminalAppearanceMethodsCrown(), code);
+
+        public async Task<string> GetCriminalAppearanceMethodAccused(string code) => FindShortDescriptionFromCode(await GetCriminalAppearanceMethodsAccused(), code);
+
+        public async Task<string> GetCriminalAppearanceMethodAccusedCounsel(string code) => FindShortDescriptionFromCode(await GetCriminalAppearancesMethodsAccusedCounsel(), code);
 
         public async Task<string> GetAgencyLocationDescription(string code) => FindLongDescriptionFromCode(await GetAgencyLocations(), code);
 

--- a/api/api.csproj
+++ b/api/api.csproj
@@ -28,5 +28,7 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Models\Civil\AppearanceDetail\" />
+    <Folder Include="Models\Civil\CourtList\" />
+    <Folder Include="Models\Criminal\CourtList\" />
   </ItemGroup>
 </Project>

--- a/jc-interface-client/API References/LookupCodeServices/LookupCodeServices-oas3.json
+++ b/jc-interface-client/API References/LookupCodeServices/LookupCodeServices-oas3.json
@@ -2364,7 +2364,7 @@
         }
       ]
     },
-    "/codes/criminal/appearance/partyAppearanceMethods/crown": {
+    "/codes/criminal/appearance/partyAttendanceTypes": {
       "get": {
         "responses": {
           "200": {
@@ -2390,11 +2390,11 @@
             }
           }
         },
-        "description": "Get a list of available crown.\n",
-        "operationId": "GET_codes-criminal-appearance-partyAppearanceMethods-crown"
+        "description": "Get a list of available partyAttendanceTypes.\n",
+        "operationId": "GET_codes-criminal-appearance-partyAttendanceTypes"
       }
     },
-    "/codes/criminal/appearance/partyAppearanceMethods/crown/{methodId}": {
+    "/codes/criminal/appearance/partyAttendanceTypes/{partyAttendanceTypeCode}": {
       "get": {
         "responses": {
           "200": {
@@ -2420,152 +2420,12 @@
             }
           }
         },
-        "description": "Get the specific crown.\n",
-        "operationId": "GET_codes-criminal-appearance-partyAppearanceMethods-crown-methodId"
+        "description": "Get the specific partyAttendanceType.\n",
+        "operationId": "GET_codes-criminal-appearance-partyAttendanceTypes-partyAttendanceTypeCode"
       },
       "parameters": [
         {
-          "name": "methodId",
-          "in": "path",
-          "required": true,
-          "schema": {
-            "type": "string"
-          }
-        }
-      ]
-    },
-    "/codes/criminal/appearance/partyAppearanceMethods/accusedCounsel": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/lookupCodes"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "example": {
-                    "message": "No items matching the given criteria were found."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "description": "Get a list of available accusedCounsel.\n",
-        "operationId": "GET_codes-criminal-appearance-partyAppearanceMethods-accusedCounsel"
-      }
-    },
-    "/codes/criminal/appearance/partyAppearanceMethods/accusedCounsel/{methodId}": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/lookupCode"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "example": {
-                    "message": "No items matching the given criteria were found."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "description": "Get the specific accusedCounsel.\n",
-        "operationId": "GET_codes-criminal-appearance-partyAppearanceMethods-accusedCounsel-methodId"
-      },
-      "parameters": [
-        {
-          "name": "methodId",
-          "in": "path",
-          "required": true,
-          "schema": {
-            "type": "string"
-          }
-        }
-      ]
-    },
-    "/codes/criminal/appearance/partyAppearanceMethods/accused": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/lookupCodes"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "example": {
-                    "message": "No items matching the given criteria were found."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "description": "Get a list of available accused.\n",
-        "operationId": "GET_codes-criminal-appearance-partyAppearanceMethods-accused"
-      }
-    },
-    "/codes/criminal/appearance/partyAppearanceMethods/accused/{methodId}": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/lookupCode"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "example": {
-                    "message": "No items matching the given criteria were found."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "description": "Get the specific accused.\n",
-        "operationId": "GET_codes-criminal-appearance-partyAppearanceMethods-accused-methodId"
-      },
-      "parameters": [
-        {
-          "name": "methodId",
+          "name": "partyAttendanceTypeCode",
           "in": "path",
           "required": true,
           "schema": {
@@ -2718,7 +2578,7 @@
   "components": {
     "schemas": {
       "lookupCode": {
-        "description": "A code value as defined in the JUTIN/CEIS web services.",
+        "description": "A code value as defined in the JUSTIN/CEIS web services.",
         "type": "object",
         "properties": {
           "codeType": {

--- a/jc-interface-client/API References/LookupCodeServices/LookupCodeServices-oas3.json
+++ b/jc-interface-client/API References/LookupCodeServices/LookupCodeServices-oas3.json
@@ -2364,6 +2364,216 @@
         }
       ]
     },
+    "/codes/criminal/appearance/partyAppearanceMethods/crown": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/lookupCodes"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {
+                    "message": "No items matching the given criteria were found."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Get a list of available crown.\n",
+        "operationId": "GET_codes-criminal-appearance-partyAppearanceMethods-crown"
+      }
+    },
+    "/codes/criminal/appearance/partyAppearanceMethods/crown/{methodId}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/lookupCode"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {
+                    "message": "No items matching the given criteria were found."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Get the specific crown.\n",
+        "operationId": "GET_codes-criminal-appearance-partyAppearanceMethods-crown-methodId"
+      },
+      "parameters": [
+        {
+          "name": "methodId",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/codes/criminal/appearance/partyAppearanceMethods/accusedCounsel": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/lookupCodes"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {
+                    "message": "No items matching the given criteria were found."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Get a list of available accusedCounsel.\n",
+        "operationId": "GET_codes-criminal-appearance-partyAppearanceMethods-accusedCounsel"
+      }
+    },
+    "/codes/criminal/appearance/partyAppearanceMethods/accusedCounsel/{methodId}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/lookupCode"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {
+                    "message": "No items matching the given criteria were found."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Get the specific accusedCounsel.\n",
+        "operationId": "GET_codes-criminal-appearance-partyAppearanceMethods-accusedCounsel-methodId"
+      },
+      "parameters": [
+        {
+          "name": "methodId",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/codes/criminal/appearance/partyAppearanceMethods/accused": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/lookupCodes"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {
+                    "message": "No items matching the given criteria were found."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Get a list of available accused.\n",
+        "operationId": "GET_codes-criminal-appearance-partyAppearanceMethods-accused"
+      }
+    },
+    "/codes/criminal/appearance/partyAppearanceMethods/accused/{methodId}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/lookupCode"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "example": {
+                    "message": "No items matching the given criteria were found."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Get the specific accused.\n",
+        "operationId": "GET_codes-criminal-appearance-partyAppearanceMethods-accused-methodId"
+      },
+      "parameters": [
+        {
+          "name": "methodId",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
     "/codes/criminal/dateDeclinedBy": {
       "get": {
         "responses": {

--- a/jc-interface-client/API References/LookupCodeServices/LookupCodeServices.raml
+++ b/jc-interface-client/API References/LookupCodeServices/LookupCodeServices.raml
@@ -17,7 +17,7 @@ schemas:
      {
        "$schema": "http://json-schema.org/draft-04/schema#",
        "type": "object",
-       "description": "A code value as defined in the JUTIN/CEIS web services.",
+       "description": "A code value as defined in the JUSTIN/CEIS web services.",
        "properties": {
          "codeType": {
            "id": "codeType",
@@ -346,23 +346,10 @@ resourceTypes:
         /{statusId}:
           type:
             readOnlyCollectionItem:
-      /partyAppearanceMethods:
-        /crown:
+      /partyAttendanceTypes:
           type:
             readOnlyCollection:
-          /{methodId}:
-            type:
-              readOnlyCollectionItem:
-        /accusedCounsel:
-          type:
-            readOnlyCollection:
-          /{methodId}:
-            type:
-              readOnlyCollectionItem:
-        /accused:
-          type:
-            readOnlyCollection:
-          /{methodId}:
+          /{partyAttendanceTypeCode}:
             type:
               readOnlyCollectionItem:
     /dateDeclinedBy:

--- a/jc-interface-client/API References/LookupCodeServices/LookupCodeServices.raml
+++ b/jc-interface-client/API References/LookupCodeServices/LookupCodeServices.raml
@@ -346,6 +346,25 @@ resourceTypes:
         /{statusId}:
           type:
             readOnlyCollectionItem:
+      /partyAppearanceMethods:
+        /crown:
+          type:
+            readOnlyCollection:
+          /{methodId}:
+            type:
+              readOnlyCollectionItem:
+        /accusedCounsel:
+          type:
+            readOnlyCollection:
+          /{methodId}:
+            type:
+              readOnlyCollectionItem:
+        /accused:
+          type:
+            readOnlyCollection:
+          /{methodId}:
+            type:
+              readOnlyCollectionItem:
     /dateDeclinedBy:
       type:
         readOnlyCollection:

--- a/jc-interface-client/Clients/LookupServiceClient.cs
+++ b/jc-interface-client/Clients/LookupServiceClient.cs
@@ -4941,17 +4941,17 @@ namespace JCCommon.Clients.LookupServices
         }
 
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public System.Threading.Tasks.Task<System.Collections.Generic.ICollection<LookupCode>> CodesCriminalAppearancePartyAppearanceMethodsCrownAsync()
+        public System.Threading.Tasks.Task<System.Collections.Generic.ICollection<LookupCode>> CodesCriminalAppearancePartyAttendanceTypesAsync()
         {
-            return CodesCriminalAppearancePartyAppearanceMethodsCrownAsync(System.Threading.CancellationToken.None);
+            return CodesCriminalAppearancePartyAttendanceTypesAsync(System.Threading.CancellationToken.None);
         }
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public async System.Threading.Tasks.Task<System.Collections.Generic.ICollection<LookupCode>> CodesCriminalAppearancePartyAppearanceMethodsCrownAsync(System.Threading.CancellationToken cancellationToken)
+        public async System.Threading.Tasks.Task<System.Collections.Generic.ICollection<LookupCode>> CodesCriminalAppearancePartyAttendanceTypesAsync(System.Threading.CancellationToken cancellationToken)
         {
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("codes/criminal/appearance/partyAppearanceMethods/crown");
+            urlBuilder_.Append("codes/criminal/appearance/partyAttendanceTypes");
 
             var client_ = _httpClient;
             try
@@ -5012,313 +5012,21 @@ namespace JCCommon.Clients.LookupServices
         }
 
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public System.Threading.Tasks.Task<LookupCode> CodesCriminalAppearancePartyAppearanceMethodsCrownMethodIdAsync(string methodId)
+        public System.Threading.Tasks.Task<LookupCode> CodesCriminalAppearancePartyAttendanceTypesPartyAttendanceTypeCodeAsync(string partyAttendanceTypeCode)
         {
-            return CodesCriminalAppearancePartyAppearanceMethodsCrownMethodIdAsync(methodId, System.Threading.CancellationToken.None);
+            return CodesCriminalAppearancePartyAttendanceTypesPartyAttendanceTypeCodeAsync(partyAttendanceTypeCode, System.Threading.CancellationToken.None);
         }
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public async System.Threading.Tasks.Task<LookupCode> CodesCriminalAppearancePartyAppearanceMethodsCrownMethodIdAsync(string methodId, System.Threading.CancellationToken cancellationToken)
+        public async System.Threading.Tasks.Task<LookupCode> CodesCriminalAppearancePartyAttendanceTypesPartyAttendanceTypeCodeAsync(string partyAttendanceTypeCode, System.Threading.CancellationToken cancellationToken)
         {
-            if (methodId == null)
-                throw new System.ArgumentNullException("methodId");
+            if (partyAttendanceTypeCode == null)
+                throw new System.ArgumentNullException("partyAttendanceTypeCode");
 
             var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("codes/criminal/appearance/partyAppearanceMethods/crown/{methodId}");
-            urlBuilder_.Replace("{methodId}", System.Uri.EscapeDataString(ConvertToString(methodId, System.Globalization.CultureInfo.InvariantCulture)));
-
-            var client_ = _httpClient;
-            try
-            {
-                using (var request_ = new System.Net.Http.HttpRequestMessage())
-                {
-                    request_.Method = new System.Net.Http.HttpMethod("GET");
-                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
-
-                    PrepareRequest(client_, request_, urlBuilder_);
-                    var url_ = urlBuilder_.ToString();
-                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
-                    PrepareRequest(client_, request_, url_);
-
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
-                    try
-                    {
-                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
-                        if (response_.Content != null && response_.Content.Headers != null)
-                        {
-                            foreach (var item_ in response_.Content.Headers)
-                                headers_[item_.Key] = item_.Value;
-                        }
-
-                        ProcessResponse(client_, response_);
-
-                        var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200")
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<LookupCode>(response_, headers_).ConfigureAwait(false);
-                            return objectResponse_.Object;
-                        }
-                        else
-                        if (status_ == "404")
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<object>(response_, headers_).ConfigureAwait(false);
-                            throw new ApiException<object>("A server side error occurred.", (int)response_.StatusCode, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
-                        if (status_ != "200" && status_ != "204")
-                        {
-                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
-                            throw new ApiException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", (int)response_.StatusCode, responseData_, headers_, null);
-                        }
-
-                        return default(LookupCode);
-                    }
-                    finally
-                    {
-                        if (response_ != null)
-                            response_.Dispose();
-                    }
-                }
-            }
-            finally
-            {
-            }
-        }
-
-        /// <exception cref="ApiException">A server side error occurred.</exception>
-        public System.Threading.Tasks.Task<System.Collections.Generic.ICollection<LookupCode>> CodesCriminalAppearancePartyAppearanceMethodsAccusedCounselAsync()
-        {
-            return CodesCriminalAppearancePartyAppearanceMethodsAccusedCounselAsync(System.Threading.CancellationToken.None);
-        }
-
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <exception cref="ApiException">A server side error occurred.</exception>
-        public async System.Threading.Tasks.Task<System.Collections.Generic.ICollection<LookupCode>> CodesCriminalAppearancePartyAppearanceMethodsAccusedCounselAsync(System.Threading.CancellationToken cancellationToken)
-        {
-            var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("codes/criminal/appearance/partyAppearanceMethods/accusedCounsel");
-
-            var client_ = _httpClient;
-            try
-            {
-                using (var request_ = new System.Net.Http.HttpRequestMessage())
-                {
-                    request_.Method = new System.Net.Http.HttpMethod("GET");
-                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
-
-                    PrepareRequest(client_, request_, urlBuilder_);
-                    var url_ = urlBuilder_.ToString();
-                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
-                    PrepareRequest(client_, request_, url_);
-
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
-                    try
-                    {
-                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
-                        if (response_.Content != null && response_.Content.Headers != null)
-                        {
-                            foreach (var item_ in response_.Content.Headers)
-                                headers_[item_.Key] = item_.Value;
-                        }
-
-                        ProcessResponse(client_, response_);
-
-                        var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200")
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<System.Collections.Generic.ICollection<LookupCode>>(response_, headers_).ConfigureAwait(false);
-                            return objectResponse_.Object;
-                        }
-                        else
-                        if (status_ == "404")
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<object>(response_, headers_).ConfigureAwait(false);
-                            throw new ApiException<object>("A server side error occurred.", (int)response_.StatusCode, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
-                        if (status_ != "200" && status_ != "204")
-                        {
-                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
-                            throw new ApiException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", (int)response_.StatusCode, responseData_, headers_, null);
-                        }
-
-                        return default(System.Collections.Generic.ICollection<LookupCode>);
-                    }
-                    finally
-                    {
-                        if (response_ != null)
-                            response_.Dispose();
-                    }
-                }
-            }
-            finally
-            {
-            }
-        }
-
-        /// <exception cref="ApiException">A server side error occurred.</exception>
-        public System.Threading.Tasks.Task<LookupCode> CodesCriminalAppearancePartyAppearanceMethodsAccusedCounselMethodIdAsync(string methodId)
-        {
-            return CodesCriminalAppearancePartyAppearanceMethodsAccusedCounselMethodIdAsync(methodId, System.Threading.CancellationToken.None);
-        }
-
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <exception cref="ApiException">A server side error occurred.</exception>
-        public async System.Threading.Tasks.Task<LookupCode> CodesCriminalAppearancePartyAppearanceMethodsAccusedCounselMethodIdAsync(string methodId, System.Threading.CancellationToken cancellationToken)
-        {
-            if (methodId == null)
-                throw new System.ArgumentNullException("methodId");
-
-            var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("codes/criminal/appearance/partyAppearanceMethods/accusedCounsel/{methodId}");
-            urlBuilder_.Replace("{methodId}", System.Uri.EscapeDataString(ConvertToString(methodId, System.Globalization.CultureInfo.InvariantCulture)));
-
-            var client_ = _httpClient;
-            try
-            {
-                using (var request_ = new System.Net.Http.HttpRequestMessage())
-                {
-                    request_.Method = new System.Net.Http.HttpMethod("GET");
-                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
-
-                    PrepareRequest(client_, request_, urlBuilder_);
-                    var url_ = urlBuilder_.ToString();
-                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
-                    PrepareRequest(client_, request_, url_);
-
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
-                    try
-                    {
-                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
-                        if (response_.Content != null && response_.Content.Headers != null)
-                        {
-                            foreach (var item_ in response_.Content.Headers)
-                                headers_[item_.Key] = item_.Value;
-                        }
-
-                        ProcessResponse(client_, response_);
-
-                        var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200")
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<LookupCode>(response_, headers_).ConfigureAwait(false);
-                            return objectResponse_.Object;
-                        }
-                        else
-                        if (status_ == "404")
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<object>(response_, headers_).ConfigureAwait(false);
-                            throw new ApiException<object>("A server side error occurred.", (int)response_.StatusCode, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
-                        if (status_ != "200" && status_ != "204")
-                        {
-                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
-                            throw new ApiException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", (int)response_.StatusCode, responseData_, headers_, null);
-                        }
-
-                        return default(LookupCode);
-                    }
-                    finally
-                    {
-                        if (response_ != null)
-                            response_.Dispose();
-                    }
-                }
-            }
-            finally
-            {
-            }
-        }
-
-        /// <exception cref="ApiException">A server side error occurred.</exception>
-        public System.Threading.Tasks.Task<System.Collections.Generic.ICollection<LookupCode>> CodesCriminalAppearancePartyAppearanceMethodsAccusedAsync()
-        {
-            return CodesCriminalAppearancePartyAppearanceMethodsAccusedAsync(System.Threading.CancellationToken.None);
-        }
-
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <exception cref="ApiException">A server side error occurred.</exception>
-        public async System.Threading.Tasks.Task<System.Collections.Generic.ICollection<LookupCode>> CodesCriminalAppearancePartyAppearanceMethodsAccusedAsync(System.Threading.CancellationToken cancellationToken)
-        {
-            var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("codes/criminal/appearance/partyAppearanceMethods/accused");
-
-            var client_ = _httpClient;
-            try
-            {
-                using (var request_ = new System.Net.Http.HttpRequestMessage())
-                {
-                    request_.Method = new System.Net.Http.HttpMethod("GET");
-                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
-
-                    PrepareRequest(client_, request_, urlBuilder_);
-                    var url_ = urlBuilder_.ToString();
-                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
-                    PrepareRequest(client_, request_, url_);
-
-                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
-                    try
-                    {
-                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
-                        if (response_.Content != null && response_.Content.Headers != null)
-                        {
-                            foreach (var item_ in response_.Content.Headers)
-                                headers_[item_.Key] = item_.Value;
-                        }
-
-                        ProcessResponse(client_, response_);
-
-                        var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200")
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<System.Collections.Generic.ICollection<LookupCode>>(response_, headers_).ConfigureAwait(false);
-                            return objectResponse_.Object;
-                        }
-                        else
-                        if (status_ == "404")
-                        {
-                            var objectResponse_ = await ReadObjectResponseAsync<object>(response_, headers_).ConfigureAwait(false);
-                            throw new ApiException<object>("A server side error occurred.", (int)response_.StatusCode, objectResponse_.Text, headers_, objectResponse_.Object, null);
-                        }
-                        else
-                        if (status_ != "200" && status_ != "204")
-                        {
-                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
-                            throw new ApiException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", (int)response_.StatusCode, responseData_, headers_, null);
-                        }
-
-                        return default(System.Collections.Generic.ICollection<LookupCode>);
-                    }
-                    finally
-                    {
-                        if (response_ != null)
-                            response_.Dispose();
-                    }
-                }
-            }
-            finally
-            {
-            }
-        }
-
-        /// <exception cref="ApiException">A server side error occurred.</exception>
-        public System.Threading.Tasks.Task<LookupCode> CodesCriminalAppearancePartyAppearanceMethodsAccusedMethodIdAsync(string methodId)
-        {
-            return CodesCriminalAppearancePartyAppearanceMethodsAccusedMethodIdAsync(methodId, System.Threading.CancellationToken.None);
-        }
-
-        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-        /// <exception cref="ApiException">A server side error occurred.</exception>
-        public async System.Threading.Tasks.Task<LookupCode> CodesCriminalAppearancePartyAppearanceMethodsAccusedMethodIdAsync(string methodId, System.Threading.CancellationToken cancellationToken)
-        {
-            if (methodId == null)
-                throw new System.ArgumentNullException("methodId");
-
-            var urlBuilder_ = new System.Text.StringBuilder();
-            urlBuilder_.Append("codes/criminal/appearance/partyAppearanceMethods/accused/{methodId}");
-            urlBuilder_.Replace("{methodId}", System.Uri.EscapeDataString(ConvertToString(methodId, System.Globalization.CultureInfo.InvariantCulture)));
+            urlBuilder_.Append("codes/criminal/appearance/partyAttendanceTypes/{partyAttendanceTypeCode}");
+            urlBuilder_.Replace("{partyAttendanceTypeCode}", System.Uri.EscapeDataString(ConvertToString(partyAttendanceTypeCode, System.Globalization.CultureInfo.InvariantCulture)));
 
             var client_ = _httpClient;
             try
@@ -5766,7 +5474,7 @@ namespace JCCommon.Clients.LookupServices
         }
     }
 
-    /// <summary>A code value as defined in the JUTIN/CEIS web services.</summary>
+    /// <summary>A code value as defined in the JUSTIN/CEIS web services.</summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.1.15.0 (Newtonsoft.Json v12.0.0.0)")]
     public partial class LookupCode
     {

--- a/jc-interface-client/Clients/LookupServiceClient.cs
+++ b/jc-interface-client/Clients/LookupServiceClient.cs
@@ -4941,6 +4941,444 @@ namespace JCCommon.Clients.LookupServices
         }
 
         /// <exception cref="ApiException">A server side error occurred.</exception>
+        public System.Threading.Tasks.Task<System.Collections.Generic.ICollection<LookupCode>> CodesCriminalAppearancePartyAppearanceMethodsCrownAsync()
+        {
+            return CodesCriminalAppearancePartyAppearanceMethodsCrownAsync(System.Threading.CancellationToken.None);
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public async System.Threading.Tasks.Task<System.Collections.Generic.ICollection<LookupCode>> CodesCriminalAppearancePartyAppearanceMethodsCrownAsync(System.Threading.CancellationToken cancellationToken)
+        {
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append("codes/criminal/appearance/partyAppearanceMethods/crown");
+
+            var client_ = _httpClient;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = ((int)response_.StatusCode).ToString();
+                        if (status_ == "200")
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<System.Collections.Generic.ICollection<LookupCode>>(response_, headers_).ConfigureAwait(false);
+                            return objectResponse_.Object;
+                        }
+                        else
+                        if (status_ == "404")
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<object>(response_, headers_).ConfigureAwait(false);
+                            throw new ApiException<object>("A server side error occurred.", (int)response_.StatusCode, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ != "200" && status_ != "204")
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", (int)response_.StatusCode, responseData_, headers_, null);
+                        }
+
+                        return default(System.Collections.Generic.ICollection<LookupCode>);
+                    }
+                    finally
+                    {
+                        if (response_ != null)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+            }
+        }
+
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public System.Threading.Tasks.Task<LookupCode> CodesCriminalAppearancePartyAppearanceMethodsCrownMethodIdAsync(string methodId)
+        {
+            return CodesCriminalAppearancePartyAppearanceMethodsCrownMethodIdAsync(methodId, System.Threading.CancellationToken.None);
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public async System.Threading.Tasks.Task<LookupCode> CodesCriminalAppearancePartyAppearanceMethodsCrownMethodIdAsync(string methodId, System.Threading.CancellationToken cancellationToken)
+        {
+            if (methodId == null)
+                throw new System.ArgumentNullException("methodId");
+
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append("codes/criminal/appearance/partyAppearanceMethods/crown/{methodId}");
+            urlBuilder_.Replace("{methodId}", System.Uri.EscapeDataString(ConvertToString(methodId, System.Globalization.CultureInfo.InvariantCulture)));
+
+            var client_ = _httpClient;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = ((int)response_.StatusCode).ToString();
+                        if (status_ == "200")
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<LookupCode>(response_, headers_).ConfigureAwait(false);
+                            return objectResponse_.Object;
+                        }
+                        else
+                        if (status_ == "404")
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<object>(response_, headers_).ConfigureAwait(false);
+                            throw new ApiException<object>("A server side error occurred.", (int)response_.StatusCode, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ != "200" && status_ != "204")
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", (int)response_.StatusCode, responseData_, headers_, null);
+                        }
+
+                        return default(LookupCode);
+                    }
+                    finally
+                    {
+                        if (response_ != null)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+            }
+        }
+
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public System.Threading.Tasks.Task<System.Collections.Generic.ICollection<LookupCode>> CodesCriminalAppearancePartyAppearanceMethodsAccusedCounselAsync()
+        {
+            return CodesCriminalAppearancePartyAppearanceMethodsAccusedCounselAsync(System.Threading.CancellationToken.None);
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public async System.Threading.Tasks.Task<System.Collections.Generic.ICollection<LookupCode>> CodesCriminalAppearancePartyAppearanceMethodsAccusedCounselAsync(System.Threading.CancellationToken cancellationToken)
+        {
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append("codes/criminal/appearance/partyAppearanceMethods/accusedCounsel");
+
+            var client_ = _httpClient;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = ((int)response_.StatusCode).ToString();
+                        if (status_ == "200")
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<System.Collections.Generic.ICollection<LookupCode>>(response_, headers_).ConfigureAwait(false);
+                            return objectResponse_.Object;
+                        }
+                        else
+                        if (status_ == "404")
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<object>(response_, headers_).ConfigureAwait(false);
+                            throw new ApiException<object>("A server side error occurred.", (int)response_.StatusCode, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ != "200" && status_ != "204")
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", (int)response_.StatusCode, responseData_, headers_, null);
+                        }
+
+                        return default(System.Collections.Generic.ICollection<LookupCode>);
+                    }
+                    finally
+                    {
+                        if (response_ != null)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+            }
+        }
+
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public System.Threading.Tasks.Task<LookupCode> CodesCriminalAppearancePartyAppearanceMethodsAccusedCounselMethodIdAsync(string methodId)
+        {
+            return CodesCriminalAppearancePartyAppearanceMethodsAccusedCounselMethodIdAsync(methodId, System.Threading.CancellationToken.None);
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public async System.Threading.Tasks.Task<LookupCode> CodesCriminalAppearancePartyAppearanceMethodsAccusedCounselMethodIdAsync(string methodId, System.Threading.CancellationToken cancellationToken)
+        {
+            if (methodId == null)
+                throw new System.ArgumentNullException("methodId");
+
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append("codes/criminal/appearance/partyAppearanceMethods/accusedCounsel/{methodId}");
+            urlBuilder_.Replace("{methodId}", System.Uri.EscapeDataString(ConvertToString(methodId, System.Globalization.CultureInfo.InvariantCulture)));
+
+            var client_ = _httpClient;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = ((int)response_.StatusCode).ToString();
+                        if (status_ == "200")
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<LookupCode>(response_, headers_).ConfigureAwait(false);
+                            return objectResponse_.Object;
+                        }
+                        else
+                        if (status_ == "404")
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<object>(response_, headers_).ConfigureAwait(false);
+                            throw new ApiException<object>("A server side error occurred.", (int)response_.StatusCode, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ != "200" && status_ != "204")
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", (int)response_.StatusCode, responseData_, headers_, null);
+                        }
+
+                        return default(LookupCode);
+                    }
+                    finally
+                    {
+                        if (response_ != null)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+            }
+        }
+
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public System.Threading.Tasks.Task<System.Collections.Generic.ICollection<LookupCode>> CodesCriminalAppearancePartyAppearanceMethodsAccusedAsync()
+        {
+            return CodesCriminalAppearancePartyAppearanceMethodsAccusedAsync(System.Threading.CancellationToken.None);
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public async System.Threading.Tasks.Task<System.Collections.Generic.ICollection<LookupCode>> CodesCriminalAppearancePartyAppearanceMethodsAccusedAsync(System.Threading.CancellationToken cancellationToken)
+        {
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append("codes/criminal/appearance/partyAppearanceMethods/accused");
+
+            var client_ = _httpClient;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = ((int)response_.StatusCode).ToString();
+                        if (status_ == "200")
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<System.Collections.Generic.ICollection<LookupCode>>(response_, headers_).ConfigureAwait(false);
+                            return objectResponse_.Object;
+                        }
+                        else
+                        if (status_ == "404")
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<object>(response_, headers_).ConfigureAwait(false);
+                            throw new ApiException<object>("A server side error occurred.", (int)response_.StatusCode, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ != "200" && status_ != "204")
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", (int)response_.StatusCode, responseData_, headers_, null);
+                        }
+
+                        return default(System.Collections.Generic.ICollection<LookupCode>);
+                    }
+                    finally
+                    {
+                        if (response_ != null)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+            }
+        }
+
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public System.Threading.Tasks.Task<LookupCode> CodesCriminalAppearancePartyAppearanceMethodsAccusedMethodIdAsync(string methodId)
+        {
+            return CodesCriminalAppearancePartyAppearanceMethodsAccusedMethodIdAsync(methodId, System.Threading.CancellationToken.None);
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public async System.Threading.Tasks.Task<LookupCode> CodesCriminalAppearancePartyAppearanceMethodsAccusedMethodIdAsync(string methodId, System.Threading.CancellationToken cancellationToken)
+        {
+            if (methodId == null)
+                throw new System.ArgumentNullException("methodId");
+
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append("codes/criminal/appearance/partyAppearanceMethods/accused/{methodId}");
+            urlBuilder_.Replace("{methodId}", System.Uri.EscapeDataString(ConvertToString(methodId, System.Globalization.CultureInfo.InvariantCulture)));
+
+            var client_ = _httpClient;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = ((int)response_.StatusCode).ToString();
+                        if (status_ == "200")
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<LookupCode>(response_, headers_).ConfigureAwait(false);
+                            return objectResponse_.Object;
+                        }
+                        else
+                        if (status_ == "404")
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<object>(response_, headers_).ConfigureAwait(false);
+                            throw new ApiException<object>("A server side error occurred.", (int)response_.StatusCode, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        if (status_ != "200" && status_ != "204")
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", (int)response_.StatusCode, responseData_, headers_, null);
+                        }
+
+                        return default(LookupCode);
+                    }
+                    finally
+                    {
+                        if (response_ != null)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+            }
+        }
+
+        /// <exception cref="ApiException">A server side error occurred.</exception>
         public System.Threading.Tasks.Task<System.Collections.Generic.ICollection<LookupCode>> CodesCriminalDateDeclinedByAsync()
         {
             return CodesCriminalDateDeclinedByAsync(System.Threading.CancellationToken.None);

--- a/tests/api/Controllers/FilesControllerTests.cs
+++ b/tests/api/Controllers/FilesControllerTests.cs
@@ -369,8 +369,8 @@ namespace tests.api.Controllers
             Assert.Contains(criminalAppearanceDetail.Charges, p => p.AppearanceReasonDsc == "First Appearance");
             Assert.Contains(criminalAppearanceDetail.Charges, p => p.StatuteDsc == "offer bribe to justice/pol comm/peac off");
             Assert.Contains(criminalAppearanceDetail.Charges, p => p.StatuteSectionDsc == "CCC - 120(b)");
-            Assert.Equal(1, criminalAppearanceDetail.Accused.AppearanceMethods.Count);
-            Assert.Equal("TC", criminalAppearanceDetail.Accused.AppearanceMethods.First().AppearanceMethodCd);
+            Assert.Equal(1, criminalAppearanceDetail.AppearanceMethods.Count);
+            Assert.Equal("TC", criminalAppearanceDetail.AppearanceMethods.First().AppearanceMethodCd);
         }
 
 
@@ -390,8 +390,8 @@ namespace tests.api.Controllers
             Assert.Contains(criminalAppearanceDetail.Charges, p => p.AppearanceReasonDsc == "First Appearance");
             Assert.Contains(criminalAppearanceDetail.Charges, p => p.StatuteDsc == "offer bribe to justice/pol comm/peac off");
             Assert.Contains(criminalAppearanceDetail.Charges, p => p.StatuteSectionDsc == "CCC - 120(b)");
-            Assert.Equal(1, criminalAppearanceDetail.Accused.AppearanceMethods.Count);
-            Assert.Equal("TC", criminalAppearanceDetail.Accused.AppearanceMethods.First().AppearanceMethodCd);
+            Assert.Equal(1, criminalAppearanceDetail.AppearanceMethods.Count);
+            Assert.Equal("TC", criminalAppearanceDetail.AppearanceMethods.First().AppearanceMethodCd);
         }
 
         #region Helpers

--- a/tests/api/Controllers/FilesControllerTests.cs
+++ b/tests/api/Controllers/FilesControllerTests.cs
@@ -361,12 +361,32 @@ namespace tests.api.Controllers
         [Fact]
         public async void Criminal_Appearance_Details()
         {
-            //Unrelated fileID and appearance Id.
-            var actionResult = await _controller.GetCriminalAppearanceDetails("2000", "36548.0734");
+            var actionResult = await _controller.GetCriminalAppearanceDetails("2934", "36548.0734");
 
             var criminalAppearanceDetail = HttpResponseTest.CheckForValidHttpResponseAndReturnValue(actionResult);
             Assert.Equal(1, criminalAppearanceDetail.Charges.Count);
-            Assert.Equal("2000", criminalAppearanceDetail.JustinNo);
+            Assert.Equal("2934", criminalAppearanceDetail.JustinNo);
+            Assert.Contains(criminalAppearanceDetail.Charges, p => p.AppearanceReasonDsc == "First Appearance");
+            Assert.Contains(criminalAppearanceDetail.Charges, p => p.StatuteDsc == "offer bribe to justice/pol comm/peac off");
+            Assert.Contains(criminalAppearanceDetail.Charges, p => p.StatuteSectionDsc == "CCC - 120(b)");
+            Assert.Equal(1, criminalAppearanceDetail.AppearanceMethods.Count);
+            Assert.Equal("TC", criminalAppearanceDetail.AppearanceMethods.First().AppearanceMethodCd);
+        }
+
+
+        [Fact(Skip= "Adhoc test.")]
+        public async void Criminal_Appearance_Details_CacheTest()
+        {
+            //This fetches the FileDetail plus the appearances. So these should be cached after this call. 
+            var actionResult = await _controller.GetCriminalFileDetailByFileId("2934");
+            var fileDetail = HttpResponseTest.CheckForValidHttpResponseAndReturnValue(actionResult);
+
+            //Now call criminalAppearanceDetails. 
+            var actionResult2 = await _controller.GetCriminalAppearanceDetails("2934", "36548.0734");
+
+            var criminalAppearanceDetail = HttpResponseTest.CheckForValidHttpResponseAndReturnValue(actionResult2);
+            Assert.Equal(1, criminalAppearanceDetail.Charges.Count);
+            Assert.Equal("2934", criminalAppearanceDetail.JustinNo);
             Assert.Contains(criminalAppearanceDetail.Charges, p => p.AppearanceReasonDsc == "First Appearance");
             Assert.Contains(criminalAppearanceDetail.Charges, p => p.StatuteDsc == "offer bribe to justice/pol comm/peac off");
             Assert.Contains(criminalAppearanceDetail.Charges, p => p.StatuteSectionDsc == "CCC - 120(b)");

--- a/tests/api/Controllers/FilesControllerTests.cs
+++ b/tests/api/Controllers/FilesControllerTests.cs
@@ -361,7 +361,7 @@ namespace tests.api.Controllers
         [Fact]
         public async void Criminal_Appearance_Details()
         {
-            var actionResult = await _controller.GetCriminalAppearanceDetails("2934", "36548.0734", "19498.0042", "1");
+            var actionResult = await _controller.GetCriminalAppearanceDetails("2934", "36548.0734", "19498.0042");
 
             var criminalAppearanceDetail = HttpResponseTest.CheckForValidHttpResponseAndReturnValue(actionResult);
             Assert.Equal(1, criminalAppearanceDetail.Charges.Count);
@@ -382,7 +382,7 @@ namespace tests.api.Controllers
             var fileDetail = HttpResponseTest.CheckForValidHttpResponseAndReturnValue(actionResult);
 
             //Now call criminalAppearanceDetails. 
-            var actionResult2 = await _controller.GetCriminalAppearanceDetails("2934", "36548.0734", "19498.0042", "1");
+            var actionResult2 = await _controller.GetCriminalAppearanceDetails("2934", "36548.0734", "19498.0042");
 
             var criminalAppearanceDetail = HttpResponseTest.CheckForValidHttpResponseAndReturnValue(actionResult2);
             Assert.Equal(1, criminalAppearanceDetail.Charges.Count);
@@ -393,7 +393,7 @@ namespace tests.api.Controllers
             Assert.Equal(1, criminalAppearanceDetail.AppearanceMethods.Count);
             Assert.Equal("TC", criminalAppearanceDetail.AppearanceMethods.First().AppearanceMethodCd);
         }
-
+ 
         #region Helpers
 
         private void SetupMocks()

--- a/tests/api/Controllers/FilesControllerTests.cs
+++ b/tests/api/Controllers/FilesControllerTests.cs
@@ -361,7 +361,7 @@ namespace tests.api.Controllers
         [Fact]
         public async void Criminal_Appearance_Details()
         {
-            var actionResult = await _controller.GetCriminalAppearanceDetails("2934", "36548.0734");
+            var actionResult = await _controller.GetCriminalAppearanceDetails("2934", "36548.0734", "19498.0042", "1");
 
             var criminalAppearanceDetail = HttpResponseTest.CheckForValidHttpResponseAndReturnValue(actionResult);
             Assert.Equal(1, criminalAppearanceDetail.Charges.Count);
@@ -369,12 +369,12 @@ namespace tests.api.Controllers
             Assert.Contains(criminalAppearanceDetail.Charges, p => p.AppearanceReasonDsc == "First Appearance");
             Assert.Contains(criminalAppearanceDetail.Charges, p => p.StatuteDsc == "offer bribe to justice/pol comm/peac off");
             Assert.Contains(criminalAppearanceDetail.Charges, p => p.StatuteSectionDsc == "CCC - 120(b)");
-            Assert.Equal(1, criminalAppearanceDetail.AppearanceMethods.Count);
-            Assert.Equal("TC", criminalAppearanceDetail.AppearanceMethods.First().AppearanceMethodCd);
+            Assert.Equal(1, criminalAppearanceDetail.Accused.AppearanceMethods.Count);
+            Assert.Equal("TC", criminalAppearanceDetail.Accused.AppearanceMethods.First().AppearanceMethodCd);
         }
 
 
-        [Fact(Skip= "Adhoc test.")]
+        [Fact(Skip= "Adhoc Test")]
         public async void Criminal_Appearance_Details_CacheTest()
         {
             //This fetches the FileDetail plus the appearances. So these should be cached after this call. 
@@ -382,7 +382,7 @@ namespace tests.api.Controllers
             var fileDetail = HttpResponseTest.CheckForValidHttpResponseAndReturnValue(actionResult);
 
             //Now call criminalAppearanceDetails. 
-            var actionResult2 = await _controller.GetCriminalAppearanceDetails("2934", "36548.0734");
+            var actionResult2 = await _controller.GetCriminalAppearanceDetails("2934", "36548.0734", "19498.0042", "1");
 
             var criminalAppearanceDetail = HttpResponseTest.CheckForValidHttpResponseAndReturnValue(actionResult2);
             Assert.Equal(1, criminalAppearanceDetail.Charges.Count);
@@ -390,8 +390,8 @@ namespace tests.api.Controllers
             Assert.Contains(criminalAppearanceDetail.Charges, p => p.AppearanceReasonDsc == "First Appearance");
             Assert.Contains(criminalAppearanceDetail.Charges, p => p.StatuteDsc == "offer bribe to justice/pol comm/peac off");
             Assert.Contains(criminalAppearanceDetail.Charges, p => p.StatuteSectionDsc == "CCC - 120(b)");
-            Assert.Equal(1, criminalAppearanceDetail.AppearanceMethods.Count);
-            Assert.Equal("TC", criminalAppearanceDetail.AppearanceMethods.First().AppearanceMethodCd);
+            Assert.Equal(1, criminalAppearanceDetail.Accused.AppearanceMethods.Count);
+            Assert.Equal("TC", criminalAppearanceDetail.Accused.AppearanceMethods.First().AppearanceMethodCd);
         }
 
         #region Helpers


### PR DESCRIPTION
Added additional fields to CriminalAppearanceDetails:
        public JustinCounsel JustinCounsel { get; set; }
        public CriminalAccused Accused { get; set; }
        public Prosecutor Prosecutor { get; set; }
        public Adjudicator Adjudicator { get; set; }
        public string JudgesRecommendation { get; set; }
        public string AppearanceNote { get; set; }

Still to go: 
Clarification on a few issues - tieing courtlist witnesses to our file, what partyAppearanceMethods means and if there are any depreciated codes. 