### PR TITLE
Update vue.config.js - use Keep alive on devServer

### DIFF
--- a/web/vue.config.js
+++ b/web/vue.config.js
@@ -6,7 +6,10 @@ module.exports = {
 			historyApiFallback: true,
 			proxy: {
 				'^/api': {
-					target: "https://localhost:44369"
+					target: "https://localhost:44369",
+					headers: {
+						Connection: 'keep-alive'
+					}
 				}
 			}
 		},


### PR DESCRIPTION
Add in keep-alive for webpack, this gets rid of a 2 second delay per request. This can be quite costly on cached calls such as lookups.