### PR TITLE
Target netstandard2.0 instead of netcoreapp3.1

### DIFF
--- a/jc-interface-client/jc-interface-client.csproj
+++ b/jc-interface-client/jc-interface-client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>JCCommon</RootNamespace>
   </PropertyGroup>
 
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR changes the jc-interface-client to target netstandard2.0 instead of netcoreapp3.1. This allows .NET Framework 4.7.2 apps to consume this library.