### PR TITLE
CICD-PATCH Correct Docker build Issues on Web

### DIFF
--- a/docker/web/Dockerfile.release
+++ b/docker/web/Dockerfile.release
@@ -75,14 +75,14 @@ ARG NPM_INSTALL_ARGS
 # USER root
 WORKDIR /opt/app-root/src
 
-# Copy package.json and package-lock.json
-COPY --chmod=674 ${WEB_SRC}/package*.json .
+# Copy package.json and package-lock.json. Read only set for all categories to avoid permission issues on install.
+COPY --chmod=444 ${WEB_SRC}/package*.json .
 
 # Install packages
 RUN npm install ${NPM_INSTALL_ARGS}
 
-# Copy the source code
-COPY --chmod=674 ${WEB_SRC} .
+# Copy the source code. Read set for all categories to avoid permission issues on build.
+COPY --chmod=444 ${WEB_SRC} .
 
 RUN npm run build 
 

--- a/docker/web/Dockerfile.release
+++ b/docker/web/Dockerfile.release
@@ -69,18 +69,17 @@ ARG NODE_VERSION
 ARG WEB_SRC
 ARG NPM_INSTALL_ARGS
 
-USER root
 WORKDIR /opt/app-root/src
 
 # Copy package.json and package-lock.json
 COPY --chmod=674 ${WEB_SRC}/package*.json .
 
 # NPM INSTALL fails as root, this is due to a legacy SCSS package, this is not required in VUE3 (REMOVE WHEN UPGRADING)
-USER 104 
+# USER 104 
 # Install packages
 RUN npm install ${NPM_INSTALL_ARGS}
 # NPM INSTALL fails as root, this is due to a legacy SCSS package, this is not required in VUE3 (REMOVE WHEN UPGRADING)
-USER root
+# USER root
 
 # Copy the source code
 COPY --chmod=674 ${WEB_SRC} .

--- a/docker/web/Dockerfile.release
+++ b/docker/web/Dockerfile.release
@@ -76,13 +76,19 @@ ARG NPM_INSTALL_ARGS
 WORKDIR /opt/app-root/src
 
 # Copy package.json and package-lock.json. Read only set for all categories to avoid permission issues on install.
-COPY --chmod=444 ${WEB_SRC}/package*.json .
+# User - no specific access required
+# Group - Read/Write to update package-lock.json during npm install
+# Others - no access keeping with zero trust principle.
+COPY --chmod=060 ${WEB_SRC}/package*.json .
 
 # Install packages
 RUN npm install ${NPM_INSTALL_ARGS}
 
 # Copy the source code. Read set for all categories to avoid permission issues on build.
-COPY --chmod=444 ${WEB_SRC} .
+# User - no specific access required
+# Group - Read/Write/Execute to build the application, create dist folder and execute vue CLI commands.
+# Others - no access keeping with zero trust principle.
+COPY --chmod=070 ${WEB_SRC} .
 
 RUN npm run build 
 

--- a/docker/web/Dockerfile.release
+++ b/docker/web/Dockerfile.release
@@ -73,22 +73,17 @@ USER root
 WORKDIR /opt/app-root/src
 
 # Copy package.json and package-lock.json
-COPY ${WEB_SRC}/package*.json .
+COPY --chmod=674 ${WEB_SRC}/package*.json .
 
-# Fix file permissisons for Github agent(REMOVE WHEN MIGRATING TO VUE3)
-RUN chmod -R 674 ./
-
-# Switch from root to 104 to install package (REMOVE WHEN MIGRATING TO VUE3)
+# NPM INSTALL fails as root, this is due to a legacy SCSS package, this is not required in VUE3 (REMOVE WHEN UPGRADING)
 USER 104 
 # Install packages
 RUN npm install ${NPM_INSTALL_ARGS}
+# NPM INSTALL fails as root, this is due to a legacy SCSS package, this is not required in VUE3 (REMOVE WHEN UPGRADING)
 USER root
 
 # Copy the source code
-COPY ${WEB_SRC} .
-
-# Fix permissisons from installing with user 104 (REMOVE WHEN MIGRATING TO VUE3)
-RUN chmod -R 674 ./
+COPY --chmod=674 ${WEB_SRC} .
 
 RUN npm run build 
 
@@ -107,8 +102,8 @@ COPY ${VUE_ON_NGINX_SRC}/s2i/bin/fix-base-url /usr/libexec/s2i/fix-base-url
 
 # Fix permissions.
 USER root
-RUN chmod 674 /usr/libexec/s2i/fix-base-url
-RUN chmod -R 674 /tmp/app/dist/
+RUN chmod u+rw,g+rwx,o+r /usr/libexec/s2i/fix-base-url
+RUN chmod -R u+rw,g+rwx,o+r /tmp/app/dist/
 
 # From nginx-runtime.
 USER 104
@@ -117,4 +112,4 @@ USER 104
 # short circuit the s2i lifecycle.
 # The runtime image "loses" its s2i runtime voodoo when it 
 # is used in a dockerStrategy, which is why the explicit `CMD` is necessary
-CMD  /usr/libexec/s2i/fix-base-url
+CMD  ["/usr/libexec/s2i/fix-base-url"]

--- a/docker/web/Dockerfile.release
+++ b/docker/web/Dockerfile.release
@@ -69,17 +69,17 @@ ARG NODE_VERSION
 ARG WEB_SRC
 ARG NPM_INSTALL_ARGS
 
+# npm install fails with EACCES: permission denied when running as root user for a scss package used in Vue 2.
+# The workaround is to run the build as a non-root user and set the permissions on the files copied to the image.
+# This should be revisited when the application is upgraded to Vue 3. See bcgov/jasper repo for guidance on Vue 3 ready image.
+# USER root
 WORKDIR /opt/app-root/src
 
 # Copy package.json and package-lock.json
 COPY --chmod=674 ${WEB_SRC}/package*.json .
 
-# NPM INSTALL fails as root, this is due to a legacy SCSS package, this is not required in VUE3 (REMOVE WHEN UPGRADING)
-# USER 104 
 # Install packages
 RUN npm install ${NPM_INSTALL_ARGS}
-# NPM INSTALL fails as root, this is due to a legacy SCSS package, this is not required in VUE3 (REMOVE WHEN UPGRADING)
-# USER root
 
 # Copy the source code
 COPY --chmod=674 ${WEB_SRC} .


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----SCV-459----    

## Issue ticket number and link  
https://jag.gov.bc.ca/jira/browse/SCV-459

## Description

1. Due to Vue2.7 the NPM installation does not work on Root users, additionally assigning no user creates a permission error where `package.*.json` are not readable. This PR corrects those issues.
2. There are a few updates in the notation for assigning permissions using chmod.
    * Note that I could not find a working example of using symbolic permission assignment using the Docker COPY --chmod option.

Multiple variations of the Dockerfile has been tested:
1. Using no `USER root` statement - Manage build works locally, Fails in GH cannot read package.json
4. Using `USER 104` at the beginning of `# 2. Build web-artifacts` step - Manage build works locally, Fails in GH cannot read package.json
5. Switching to `USER 104` before `npm install` and back to `USER root` afterwards - Fails Docker build as 104 cannot read package.json
6. Removing `USER root` statement and setting permissions on COPY statements - Works both Locally and in GH:
    * https://github.com/bcgov/supreme-court-viewer/actions/runs/12891093831
    * <img width="1089" alt="image" src="https://github.com/user-attachments/assets/2bb29b54-4203-4220-9c25-930a9f9630ec" />

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update    

## How Has This Been Tested?

Application builds and deploys correctly, with working scenario in websm and web:
Websm:
![image](https://github.com/user-attachments/assets/40d4847c-eb1d-4a10-9b38-2bb324a57f84)

Web:
![image](https://github.com/user-attachments/assets/5d8666bf-c3a0-40f0-8c11-10f51237b46d)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules   
