### PR TITLE
Add support for updated VC username syntax

### DIFF
--- a/api/Helpers/Extensions/ClaimsPrincipalExtensions.cs
+++ b/api/Helpers/Extensions/ClaimsPrincipalExtensions.cs
@@ -47,7 +47,8 @@ namespace Scv.Api.Helpers.Extensions
 
         public static bool IsVcUser(this ClaimsPrincipal claimsPrincipal)
             => claimsPrincipal.HasClaim(c => c.Type == CustomClaimTypes.PreferredUsername) &&
-               claimsPrincipal.FindFirstValue(CustomClaimTypes.PreferredUsername).EndsWith("@vc");
+               (claimsPrincipal.FindFirstValue(CustomClaimTypes.PreferredUsername).EndsWith("@accredited-lawyer-bcpc") ||
+                claimsPrincipal.FindFirstValue(CustomClaimTypes.PreferredUsername).EndsWith("@vc"));
 
         public static bool IsSupremeUser(this ClaimsPrincipal claimsPrincipal)
         => claimsPrincipal.HasClaim(c => c.Type == CustomClaimTypes.IsSupremeUser) &&

--- a/api/Helpers/XForwardedForHelper.cs
+++ b/api/Helpers/XForwardedForHelper.cs
@@ -1,11 +1,28 @@
 ﻿using System;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Tokens;
 
 namespace Scv.Api.Helpers
 {
     public static class XForwardedForHelper
     {
+        private static readonly ILogger _logger;
+
+        static XForwardedForHelper()
+        {
+            using ILoggerFactory factory = LoggerFactory.Create(builder => builder.AddConsole());
+            _logger = factory.CreateLogger("XForwardedForHelper");
+        }
+
         public static string BuildUrlString(string forwardedHost, string forwardedPort, string baseUrl, string remainingPath = "", string query = "")
         {
+            // _logger.LogInformation($"XForwardedForHelper - forwardedHost: `{forwardedHost}`, forwardedPort: `{forwardedPort}`, baseUrl: `{baseUrl}`, remainingPath: `{remainingPath}`, query: `{query}`");
+
+            // Default: Assume the code is running as Court Viewer locally, unless specified.
+            forwardedHost = forwardedHost.IsNullOrEmpty() ? "localhost" : forwardedHost;
+            forwardedPort = forwardedPort.IsNullOrEmpty() ? "8080" : forwardedPort;
+            baseUrl = baseUrl.IsNullOrEmpty() ? "/court-viewer/" : baseUrl;
+
             var sanitizedPath = baseUrl;
             var isLocalhost = forwardedHost.Contains("localhost");
             if (!string.IsNullOrEmpty(remainingPath))
@@ -34,6 +51,7 @@ namespace Scv.Api.Helpers
                 uriBuilder.Port = port;
             }
 
+            _logger.LogInformation($"uriBuilder.Uri.AbsoluteUri `{uriBuilder.Uri.AbsoluteUri}`");
             return uriBuilder.Uri.AbsoluteUri;
         }
     }


### PR DESCRIPTION
- VC-Authn has been updated to include the pres_req_conf_id as part of the username, to make the usernames unique across various presentation requests.
- The verifiable-credential IdP used by the ACM (A2A) client has been updated to pass the VC-Authn username through, eliminating the `@vc` suffix.
- The code has been updated to support both formats for now.

- Add logging to XForwardedForHelper and make it easier to test things locally.

This has been tested locally with the indicated updates to VC-Authn and KeyCloak.