### PR TITLE
Maint: Pin npm install in docker to node 12 compliance

### DIFF
--- a/docker/web/Dockerfile.release
+++ b/docker/web/Dockerfile.release
@@ -81,8 +81,10 @@ WORKDIR /opt/app-root/src
 # Others - no access keeping with zero trust principle.
 COPY --chmod=060 ${WEB_SRC}/package*.json .
 
-# Install packages
-RUN npm install ${NPM_INSTALL_ARGS}
+# Install packages. Skip lifecycle scripts to keep the forced resolutions hook from
+# floating transitive dependencies beyond what this Node 12 build supports.
+RUN npm install --ignore-scripts ${NPM_INSTALL_ARGS}
+RUN npm rebuild node-sass
 
 # Copy the source code. Read set for all categories to avoid permission issues on build.
 # User - no specific access required

--- a/docker/web/Dockerfile.release
+++ b/docker/web/Dockerfile.release
@@ -83,7 +83,7 @@ COPY --chmod=060 ${WEB_SRC}/package*.json .
 
 # Install packages. Skip lifecycle scripts to keep the forced resolutions hook from
 # floating transitive dependencies beyond what this Node 12 build supports.
-RUN npm install --ignore-scripts ${NPM_INSTALL_ARGS}
+RUN npm ci --ignore-scripts ${NPM_INSTALL_ARGS}
 RUN npm rebuild node-sass
 
 # Copy the source code. Read set for all categories to avoid permission issues on build.


### PR DESCRIPTION
Maintenance bump - fixing trivy scan action findings.

## Summary
This pull request updates the Node.js package installation process in the `docker/web/Dockerfile.release` to improve build reliability and compatibility with Node 12. The main changes are:

Dependency installation changes:
* The `npm install` command now uses the `--ignore-scripts` flag to skip running lifecycle scripts, preventing the forced resolutions hook from updating transitive dependencies beyond what Node 12 supports.
* Added a separate `npm rebuild node-sass` step to ensure `node-sass` is properly rebuilt after the installation, maintaining compatibility with the build environment.