### PR TITLE
CSBVC-122: Fix Incorrect youth Criminal File Access

### DIFF
--- a/api/Controllers/FilesController.cs
+++ b/api/Controllers/FilesController.cs
@@ -324,15 +324,34 @@ namespace Scv.Api.Controllers
                             .SelectMany(p => p.Document)
                             .FirstOrDefault(d => d.ImageId == documentId);
 
-                        if (document?.DocmClassification.ToLower() == "sentencing")
+                        var youthForm = document?.DocmFormDsc;
+
+                        var allowedYouthDocuments = new[]
+                        {
+                            "Release Order",
+                            "Information"
+                        };
+
+                        bool isYouthDocAllowed = youthForm != null &&
+                            allowedYouthDocuments.Any(p => youthForm.Equals(p, StringComparison.OrdinalIgnoreCase));
+                            
+                        if (!isYouthDocAllowed)
                         {
                             return this.FileAccessDenied();
                         }
-                        if (document?.DocmClassification.ToLower() == "bail" &&
-                            DateTime.TryParse(document.DocmDispositionDate?.ToString(), out var dispositionDate) &&
-                            DateTime.Today > dispositionDate.AddDays(60))
+
+                        var youthAppearances = criminalFileDetailResponse.Appearances?.ApprDetail;
+                        if (youthAppearances != null)
                         {
-                            return this.FileAccessDenied();
+                            bool hasExpiredEndResult = youthAppearances.Any(a =>
+                                string.Equals(a.AppearanceResultCd, "END", StringComparison.OrdinalIgnoreCase) &&
+                                DateTime.TryParse(a.AppearanceDt, out var appearanceDt) &&
+                                DateTime.Today > appearanceDt.AddDays(60));
+
+                            if (hasExpiredEndResult)
+                            {
+                                return this.FileAccessDenied();
+                            }
                         }
                     }
 
@@ -349,7 +368,7 @@ namespace Scv.Api.Controllers
 
                         var form = document?.DocmFormDsc;
 
-                        var allowedDocuments = new[]
+                        var allowedAdultDocuments = new[]
                         {
                             "Release Order",
                             "Information",
@@ -357,7 +376,7 @@ namespace Scv.Api.Controllers
                         };
 
                         bool isAllowed = form != null &&
-                                         allowedDocuments.Any(p =>
+                                         allowedAdultDocuments.Any(p =>
                                              form.Equals(p, StringComparison.OrdinalIgnoreCase) ||
                                              form.StartsWith("Probation Order", StringComparison.OrdinalIgnoreCase));
 


### PR DESCRIPTION
# Pull Request for JIRA Ticket: ----**[CSBVC-122](https://jira.justice.gov.bc.ca/browse/CSBVC-122)**----    

## Description

Counsel access to Youh files in ACM should follow these rules:
- If there is no disposition entered, counsel should be allowed access.
- If there is a disposition and the date of disposition is 60 days or less, counsel should be allowed access.
- If there is a disposition and it has been more than 60 days, counsel should not be allowed access.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
